### PR TITLE
Drop Nordnet rating stat

### DIFF
--- a/e2e/site.spec.ts
+++ b/e2e/site.spec.ts
@@ -34,10 +34,11 @@ for (const { path, heading } of PAGES) {
   });
 }
 
-test("homepage has no Følgere stat", async ({ page }) => {
+test("homepage has no Følgere or Vurdering stats", async ({ page }) => {
   await page.goto("/");
   await page.waitForLoadState("networkidle");
   await expect(page.getByText("Følgere")).toHaveCount(0);
+  await expect(page.getByText("Vurdering")).toHaveCount(0);
 });
 
 test("mobile menu opens and navigates", async ({ page, isMobile }) => {

--- a/src/components/NordnetProfileCard.tsx
+++ b/src/components/NordnetProfileCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useQuery } from "@tanstack/react-query";
-import { Star, ExternalLink } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import type { NordnetData } from "@/lib/nordnet-types";
 
 const NORDNET_PROFILE_URL =
@@ -51,13 +51,6 @@ export default function NordnetProfileCard() {
           </p>
         </div>
         <div className="flex items-center gap-6">
-          <div className="text-center">
-            <p className="text-lg font-semibold text-foreground-primary flex items-center gap-1 justify-center">
-              {profile.rating}/3
-              <Star className="w-4 h-4 fill-current text-warning" />
-            </p>
-            <p className="text-xs text-foreground-secondary">Vurdering</p>
-          </div>
           <a
             href={NORDNET_PROFILE_URL}
             target="_blank"


### PR DESCRIPTION
Removes the 3/3 Vurdering stat from the profile card, leaving only the Nordnet link. e2e test extended to assert both removed stats stay gone.