### PR TITLE
Serve member images from a runtime volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Optional. Absolute path to a directory of member portraits and group photos
+# served at runtime via /api/members/<file>. In production this is a mounted
+# volume so images live on the server, not in the repo or the built image.
+# Unset falls back to public/members (used for local dev and CI).
+MEMBERS_IMAGE_DIR=

--- a/README.md
+++ b/README.md
@@ -122,18 +122,29 @@ flowchart TD
 ```
 
 - Støttede bildeformater: jpg, jpeg, png, webp. Anbefalt stående 3:4,
-  minst 600 px bredt. Oppslaget skjer i `src/lib/member-images.ts`.
-- Gruppebilde: legg `group.jpg` (eller png/webp) i `public/members/`.
+  minst 600 px bredt. Oppslaget skjer i `src/lib/member-images.ts` og
+  bildene serveres via `/api/members/<fil>`.
+- Gruppebilde: legg `group.jpg` (eller png/webp) i samme mappe.
 - Mangler bildet, vises en nøytral plassholder. Ingenting knekker.
+- I produksjon ligger bildene på et montert volum, ikke i repoet: sett
+  `MEMBERS_IMAGE_DIR` til volum-mappen (systemd-enheten monterer
+  `~/srv/Fondet/data/members` til `/app/data/members`). Nye bilder legges
+  der på serveren, ikke i `public/members`. Er `MEMBERS_IMAGE_DIR` ikke satt,
+  brukes `public/members` (lokal utvikling og CI), som også er reserve i
+  produksjon slik at allerede committede bilder fortsatt virker.
 
 ## Miljøvariabler
 
-Kun én, og den er valgfri. Opprett `.env.local` i rotmappen:
+Begge er valgfrie. Opprett `.env.local` i rotmappen:
 
 ```
 # Resend-nøkkel for søknadsskjemaet (gratis: 100 e-poster/dag).
 # Uten nøkkel svarer skjemaet med en tydelig feilmelding.
 RESEND_API_KEY=
+
+# Mappe med medlems- og gruppebilder, servert via /api/members/<fil>.
+# Settes i produksjon til et montert volum. Uten verdi brukes public/members.
+MEMBERS_IMAGE_DIR=
 ```
 
 Merk: Resend sender fra `onboarding@resend.dev` til domenet er verifisert.

--- a/src/app/api/members/[file]/route.ts
+++ b/src/app/api/members/[file]/route.ts
@@ -1,0 +1,36 @@
+import fs from "fs";
+import path from "path";
+import { membersImageDirs } from "@/lib/member-images";
+
+const TYPES: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+};
+
+// Serves member portraits and group photos from the configured image
+// directories (a mounted volume in production, public/members otherwise).
+export async function GET(
+  _req: Request,
+  { params }: { params: { file: string } },
+) {
+  const safe = path.basename(params.file);
+  const ext = path.extname(safe).toLowerCase();
+  const type = TYPES[ext];
+  if (!type) return new Response("Not found", { status: 404 });
+
+  for (const dir of membersImageDirs()) {
+    const full = path.join(dir, safe);
+    if (!full.startsWith(path.resolve(dir))) continue;
+    if (!fs.existsSync(full)) continue;
+    const data = await fs.promises.readFile(full);
+    return new Response(new Uint8Array(data), {
+      headers: {
+        "Content-Type": type,
+        "Cache-Control": "public, max-age=3600, must-revalidate",
+      },
+    });
+  }
+  return new Response("Not found", { status: 404 });
+}

--- a/src/lib/member-images.ts
+++ b/src/lib/member-images.ts
@@ -1,19 +1,32 @@
-// Server-only helpers. Portraits follow a file convention so maintainers
-// just drop an image into public/members/ named after the member id in
-// members.json, e.g. public/members/kaja-saetherhaug-dalamo.jpg.
-// An explicit image URL in members.json wins over the convention.
+// Server-only helpers. Portraits and group photos are served at runtime via
+// /api/members/<file>. In production MEMBERS_IMAGE_DIR points at a mounted
+// volume so images live on the server, not in the repo or the built image;
+// maintainers drop a file named after the member id in members.json, e.g.
+// tri-tac-le.jpg. Unset (dev/CI) falls back to public/members, which is also
+// searched second in production so already-committed portraits keep working.
+// An explicit image URL in members.json always wins over this convention.
 
 import fs from "fs";
 import path from "path";
 import type { Member } from "@/data/members";
 
-const MEMBERS_DIR = path.join(process.cwd(), "public", "members");
 const EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"];
 
+// Directories searched in order; the volume (if configured) overrides the
+// repo copy, and the repo copy is the fallback.
+export function membersImageDirs(): string[] {
+  const dirs: string[] = [];
+  if (process.env.MEMBERS_IMAGE_DIR) dirs.push(process.env.MEMBERS_IMAGE_DIR);
+  dirs.push(path.join(process.cwd(), "public", "members"));
+  return dirs;
+}
+
 function findLocalImage(id: string): string {
-  for (const ext of EXTENSIONS) {
-    if (fs.existsSync(path.join(MEMBERS_DIR, id + ext))) {
-      return `/members/${id}${ext}`;
+  for (const dir of membersImageDirs()) {
+    for (const ext of EXTENSIONS) {
+      if (fs.existsSync(path.join(dir, id + ext))) {
+        return `/api/members/${id}${ext}`;
+      }
     }
   }
   return "";
@@ -25,26 +38,31 @@ export function withImages(members: Member[]): Member[] {
   );
 }
 
+function groupNumber(file: string): number {
+  const m = file.match(/^group-(\d+)\./i);
+  return m ? parseInt(m[1], 10) : 1;
+}
+
 // All group photos for the carousel: group.jpg first, then group-2.jpg,
-// group-3.jpg and so on, sorted by name. Falls back to the single image.
+// group-3.jpg and so on. Falls back to the single image.
 export function resolveGroupImages(fallback: string): string[] {
-  let files: string[] = [];
-  try {
-    files = fs.readdirSync(MEMBERS_DIR);
-  } catch {
-    return fallback ? [fallback] : [];
+  const byName = new Map<string, string>();
+  for (const dir of membersImageDirs()) {
+    let files: string[] = [];
+    try {
+      files = fs.readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const f of files) {
+      if (/^group(-\d+)?\.(jpg|jpeg|png|webp)$/i.test(f) && !byName.has(f)) {
+        byName.set(f, `/api/members/${f}`);
+      }
+    }
   }
-  const images = files
-    .filter((f) => /^group(-\d+)?\.(jpg|jpeg|png|webp)$/i.test(f))
-    // group.jpg first, then group-2, group-3, ...
-    .sort((a, b) => {
-      const num = (f: string) => {
-        const m = f.match(/^group-(\d+)\./i);
-        return m ? parseInt(m[1], 10) : 1;
-      };
-      return num(a) - num(b);
-    })
-    .map((f) => `/members/${f}`);
+  const images = Array.from(byName.keys())
+    .sort((a, b) => groupNumber(a) - groupNumber(b))
+    .map((f) => byName.get(f)!);
   if (images.length > 0) return images;
   return fallback ? [fallback] : [];
 }

--- a/systemd/fondet.service
+++ b/systemd/fondet.service
@@ -11,6 +11,8 @@ ExecStart=/usr/bin/docker run --rm \
     --pull=always \
     -p 127.0.0.1:3005:3000 \
     --env-file %h/srv/Fondet/.env \
+    -e MEMBERS_IMAGE_DIR=/app/data/members \
+    -v %h/srv/Fondet/data/members:/app/data/members \
     ghcr.io/tihlde/fondet:dev
 ExecStop=/usr/bin/docker stop fondet
 Restart=always


### PR DESCRIPTION
Member portraits and group photos now serve via `/api/members/<file>` from `MEMBERS_IMAGE_DIR` (a mounted volume in production), with `public/members` as fallback so already-committed images keep working. Images no longer have to live in the repo or the built image; maintainers drop new files on the server volume.

- New route `src/app/api/members/[file]/route.ts` (path-traversal guarded, content-type + cache headers).
- `member-images.ts` searches the volume then public/members.
- systemd unit mounts `~/srv/Fondet/data/members` -> `/app/data/members` and sets the env var.
- `.env.example` + README document the var and the prod flow.

Verified: tsc/eslint clean, route serves an existing portrait (200) and a group photo, blocks traversal (404), and /group renders all images through the new URL.