### PR TITLE
Silence DEP0205 deprecation from vitest loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "NODE_OPTIONS=--disable-warning=DEP0205 vitest run",
+    "test:watch": "NODE_OPTIONS=--disable-warning=DEP0205 vitest",
     "test:e2e": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
Node 26 flags vitest 4.1.10's internal `module.register()` call (DEP0205). vitest hasn't shipped a `module.registerHooks()` migration yet and we're already on the latest release, so this scope-suppresses only that warning id in the test scripts instead of hiding all deprecations. 33 tests still pass.