### PR TITLE
Fix member and group images not rendering on Vercel

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,16 @@
 const nextConfig = {
   // Standalone output so the Docker image only ships the compiled server.
   output: "standalone",
+  experimental: {
+    // The group pages enumerate public/members at runtime to build the member
+    // grid and archive carousel. On serverless (Vercel) that folder is not in
+    // the function bundle by default, so force it in or the scans come back
+    // empty and no portraits render.
+    outputFileTracingIncludes: {
+      "/group": ["./public/members/**/*"],
+      "/group/tidligere": ["./public/members/**/*"],
+    },
+  },
   images: {
     remotePatterns: [
       {

--- a/src/lib/member-images.test.ts
+++ b/src/lib/member-images.test.ts
@@ -13,16 +13,16 @@ function member(id: string, image = ""): Member {
 describe("resolveGroupImages", () => {
   it("returns group.jpg first, then numbered images", () => {
     const images = resolveGroupImages("");
-    expect(images[0]).toBe("/api/members/group.jpg");
-    expect(images).toContain("/api/members/group-2.jpg");
-    expect(images).toContain("/api/members/group-3.jpg");
+    expect(images[0]).toBe("/members/group.jpg");
+    expect(images).toContain("/members/group-2.jpg");
+    expect(images).toContain("/members/group-3.jpg");
     const numbered = images.slice(1);
     expect(numbered).toEqual([...numbered].sort());
   });
 
   it("only returns group images", () => {
     for (const img of resolveGroupImages("")) {
-      expect(img).toMatch(/^\/api\/members\/group(-\d+)?\.(jpg|jpeg|png|webp)$/);
+      expect(img).toMatch(/^\/members\/group(-\d+)?\.(jpg|jpeg|png|webp)$/);
     }
   });
 });
@@ -32,7 +32,7 @@ describe("resolveArchiveGroupImages", () => {
     const archive = resolveArchiveGroupImages();
     expect(archive.length).toBeGreaterThan(0);
     for (const { src, year } of archive) {
-      expect(src).toMatch(/^\/api\/members\/group-\d{4}-\d+\.(jpg|jpeg|png|webp)$/);
+      expect(src).toMatch(/^\/members\/group-\d{4}-\d+\.(jpg|jpeg|png|webp)$/);
       expect(year).toMatch(/^\d{4}$/);
     }
     const years = archive.map((a) => a.year);
@@ -51,7 +51,7 @@ describe("resolveArchiveGroupImages", () => {
 describe("withImages", () => {
   it("finds a portrait by member id convention", () => {
     const [m] = withImages([member("martine-lokstad")]);
-    expect(m.image).toBe("/api/members/martine-lokstad.jpg");
+    expect(m.image).toBe("/members/martine-lokstad.jpg");
   });
 
   it("leaves members without a portrait empty", () => {

--- a/src/lib/member-images.ts
+++ b/src/lib/member-images.ts
@@ -12,20 +12,30 @@ import type { Member } from "@/data/members";
 
 const EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"];
 
+const REPO_DIR = path.join(process.cwd(), "public", "members");
+
 // Directories searched in order; the volume (if configured) overrides the
 // repo copy, and the repo copy is the fallback.
 export function membersImageDirs(): string[] {
   const dirs: string[] = [];
   if (process.env.MEMBERS_IMAGE_DIR) dirs.push(process.env.MEMBERS_IMAGE_DIR);
-  dirs.push(path.join(process.cwd(), "public", "members"));
+  dirs.push(REPO_DIR);
   return dirs;
+}
+
+// Public URL for a resolved file. Committed images under public/members are
+// served straight from /members by the static host (works on serverless too,
+// where the API route can't read files bundled outside the function). Volume
+// images have no static URL, so those go through the API route.
+function urlFor(dir: string, file: string): string {
+  return dir === REPO_DIR ? `/members/${file}` : `/api/members/${file}`;
 }
 
 function findLocalImage(id: string): string {
   for (const dir of membersImageDirs()) {
     for (const ext of EXTENSIONS) {
       if (fs.existsSync(path.join(dir, id + ext))) {
-        return `/api/members/${id}${ext}`;
+        return urlFor(dir, id + ext);
       }
     }
   }
@@ -56,7 +66,7 @@ export function resolveGroupImages(fallback: string): string[] {
     }
     for (const f of files) {
       if (/^group(-\d+)?\.(jpg|jpeg|png|webp)$/i.test(f) && !byName.has(f)) {
-        byName.set(f, `/api/members/${f}`);
+        byName.set(f, urlFor(dir, f));
       }
     }
   }
@@ -89,7 +99,7 @@ export function resolveArchiveGroupImages(): ArchiveGroupImage[] {
     for (const f of files) {
       const parsed = archiveYear(f);
       if (parsed && !byName.has(f)) {
-        byName.set(f, { src: `/api/members/${f}`, year: parsed.year });
+        byName.set(f, { src: urlFor(dir, f), year: parsed.year });
       }
     }
   }


### PR DESCRIPTION
## Problem
On the Vercel deploy, member portraits fell back to the placeholder icon and the "tidligere medlemmer" archive carousel showed nothing. Locally it worked.

## Cause
Images resolved to `/api/members/<file>`, and both that route and the page-level `public/members` directory scans read files off disk with `fs`. Vercel's serverless functions don't include `public/` in the bundle, so every lookup 404'd. Static `/members/<file>` worked the whole time (the CDN serves `public/`); only the `fs` indirection was broken.

## Fix
- Committed images under `public/members` now resolve to their static `/members/<file>` URL (served by the CDN on any host). `/api/members` stays for volume-mounted images in the self-hosted Docker setup.
- `outputFileTracingIncludes` pulls `public/members/**` into the `/group` and `/group/tidligere` functions so the runtime enumeration (which group photos exist, which portrait extension) still finds the files.

## Verified
- Build trace now lists the member files under the group function's `.nft.json`.
- Standalone server renders `/members/...` srcs for portraits and archive photos; both static and API paths return 200.
- tsc, eslint, 33 unit tests pass (updated the 4 tests that asserted the old `/api/members` URLs).