### PR TITLE
Show published portfolio weights (fordeling) on holdings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,9 @@ const nextConfig = {
     outputFileTracingIncludes: {
       "/group": ["./public/members/**/*"],
       "/group/tidligere": ["./public/members/**/*"],
+      // The holdings endpoint reads the quarterly report PDFs at runtime to pull
+      // published portfolio weights, so they must be traced into the function.
+      "/api/nordnet": ["./public/reports/**/*"],
     },
   },
   images: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "sharp": "^0.35.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
+        "unpdf": "^1.6.2",
         "vaul": "^1.1.2"
       },
       "devDependencies": {
@@ -8166,6 +8167,20 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpdf": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "sharp": "^0.35.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
+    "unpdf": "^1.6.2",
     "vaul": "^1.1.2"
   },
   "devDependencies": {

--- a/src/app/api/nordnet/route.ts
+++ b/src/app/api/nordnet/route.ts
@@ -1,15 +1,25 @@
 import { NextResponse } from "next/server";
 import { getProfile, getTrades, getHoldings } from "@/lib/nordnet";
+import { getReportWeights, weightFor } from "@/lib/fordeling";
 
 export const revalidate = 1800;
 
 export async function GET() {
-  const [profile, trades] = await Promise.all([getProfile(), getTrades()]);
+  const [profile, trades, report] = await Promise.all([
+    getProfile(),
+    getTrades(),
+    getReportWeights(),
+  ]);
   const holdings = await getHoldings(trades);
+  const withWeights = holdings.map((h) => ({
+    ...h,
+    weight: weightFor(h.name, report),
+  }));
 
   return NextResponse.json({
     profile,
-    holdings,
+    holdings: withWeights,
     trades: trades.slice(0, 100),
+    weightAsOf: report?.period ?? null,
   });
 }

--- a/src/components/HoldingsTable.tsx
+++ b/src/components/HoldingsTable.tsx
@@ -14,6 +14,21 @@ function Pct({ value }: { value: number | null }) {
   );
 }
 
+function Weight({ value }: { value: number | null }) {
+  if (value === null) {
+    return (
+      <span className="inline-block rounded bg-cardBorder/50 px-2 py-0.5 text-xs font-medium text-foreground-secondary">
+        Ny
+      </span>
+    );
+  }
+  return (
+    <span className="text-foreground-primary">
+      {value.toFixed(2).replace(".", ",")} %
+    </span>
+  );
+}
+
 export default function HoldingsTable() {
   const { data, isLoading } = useNordnet();
 
@@ -24,6 +39,7 @@ export default function HoldingsTable() {
   }
 
   const holdings = data?.holdings ?? [];
+  const weightAsOf = data?.weightAsOf ?? null;
   if (holdings.length === 0) {
     return (
       <p className="text-foreground-secondary">
@@ -44,6 +60,9 @@ export default function HoldingsTable() {
             <tr className="border-b border-cardBorder">
               <th className="text-left py-3 px-4 text-foreground-primary font-semibold">
                 Fond
+              </th>
+              <th className="text-right py-3 px-4 text-foreground-primary font-semibold">
+                Andel
               </th>
               <th className="text-right py-3 px-4 text-foreground-primary font-semibold">
                 Kurs (NAV)
@@ -79,6 +98,9 @@ export default function HoldingsTable() {
                     <span>{h.name}</span>
                   </div>
                 </td>
+                <td className="py-3 px-4 text-right whitespace-nowrap">
+                  <Weight value={h.weight} />
+                </td>
                 <td className="py-3 px-4 text-right text-foreground-secondary whitespace-nowrap">
                   {h.nav !== null
                     ? h.nav.toLocaleString("nb-NO", {
@@ -101,6 +123,13 @@ export default function HoldingsTable() {
           </tbody>
         </table>
       </div>
+
+      {weightAsOf && (
+        <p className="mt-4 text-sm text-foreground-secondary">
+          Andel er publisert porteføljevekt fra rapporten for {weightAsOf}. Fond
+          merket «Ny» er kjøpt etter rapporten og har ingen publisert vekt ennå.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/fordeling.ts
+++ b/src/lib/fordeling.ts
@@ -1,0 +1,144 @@
+// Portfolio weights ("fordeling") are not exposed by any public Nordnet API.
+// The Forvaltningsgruppen publishes them each quarter in the report PDFs under
+// public/reports, one line per fund: "<Fund> - Porteføljevekt: NN,NN %". This
+// reads the newest report, extracts those weights, and matches them to the
+// funds Nordnet currently reports as held. A fund held but not in the report
+// (bought after it was written) has no published weight yet; a fund in the
+// report but no longer held (sold) simply never gets matched.
+
+import fs from "fs";
+import path from "path";
+import { getDocumentProxy, extractText } from "unpdf";
+
+const REPORTS_DIR = path.join(process.cwd(), "public", "reports");
+
+export interface ReportWeights {
+  period: string;
+  weights: { name: string; weight: number }[];
+}
+
+interface ReportFile {
+  file: string;
+  rank: number;
+  isQuarter: boolean;
+  label: string;
+}
+
+// Newest first; a quarterly report wins over the annual one for the same year,
+// since the annual is often still a draft when the Q4 numbers are already final.
+function reportFiles(): ReportFile[] {
+  let files: string[] = [];
+  try {
+    files = fs.readdirSync(REPORTS_DIR);
+  } catch {
+    return [];
+  }
+  const parsed: ReportFile[] = [];
+  for (const file of files) {
+    const q = file.match(/kvartalsrapport-q(\d)-(\d{4})/i);
+    if (q) {
+      const year = parseInt(q[2], 10);
+      parsed.push({
+        file,
+        rank: year * 10 + parseInt(q[1], 10),
+        isQuarter: true,
+        label: `Q${q[1]} ${year}`,
+      });
+      continue;
+    }
+    const a = file.match(/arsrapport-(\d{4})/i);
+    if (a) {
+      const year = parseInt(a[1], 10);
+      parsed.push({
+        file,
+        rank: year * 10 + 4,
+        isQuarter: false,
+        label: `Årsrapport ${year}`,
+      });
+    }
+  }
+  return parsed.sort((l, r) =>
+    r.rank !== l.rank ? r.rank - l.rank : Number(r.isQuarter) - Number(l.isQuarter),
+  );
+}
+
+function parseWeights(text: string): { name: string; weight: number }[] {
+  // The fund name sits right before "- Porteføljevekt: NN %", anchored to the
+  // preceding sentence end so the description of the previous fund is not
+  // swept into the name.
+  const re =
+    /[.»]\s*([A-ZÆØÅÖ][^–]{2,50}?)\s*[–-]\s*Portef(?:ø|o)ljevekt:\s*(\d+[.,]\d+)\s*%/gi;
+  const seen = new Set<string>();
+  const out: { name: string; weight: number }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    const name = m[1].trim().replace(/\s+/g, " ");
+    if (seen.has(name)) continue;
+    seen.add(name);
+    out.push({ name, weight: parseFloat(m[2].replace(",", ".")) });
+  }
+  return out;
+}
+
+async function extractReport(file: string): Promise<ReportWeights | null> {
+  let buf: Buffer;
+  try {
+    buf = await fs.promises.readFile(path.join(REPORTS_DIR, file));
+  } catch {
+    return null;
+  }
+  const pdf = await getDocumentProxy(new Uint8Array(buf));
+  const { text } = await extractText(pdf, { mergePages: true });
+  return { period: "", weights: parseWeights(text) };
+}
+
+// A report is only trusted if it yields a plausible full allocation: enough
+// funds and a total near 100 %. This filters out half-written drafts.
+function isValid(w: { weight: number }[]): boolean {
+  if (w.length < 4) return false;
+  const sum = w.reduce((s, x) => s + x.weight, 0);
+  return sum >= 80 && sum <= 120;
+}
+
+let cache: { key: string; value: ReportWeights | null } | null = null;
+
+export async function getReportWeights(): Promise<ReportWeights | null> {
+  const candidates = reportFiles();
+  const key = candidates.map((c) => c.file).join("|");
+  if (cache && cache.key === key) return cache.value;
+
+  let value: ReportWeights | null = null;
+  for (const candidate of candidates) {
+    const report = await extractReport(candidate.file);
+    if (report && isValid(report.weights)) {
+      value = { period: candidate.label, weights: report.weights };
+      break;
+    }
+  }
+  cache = { key, value };
+  return value;
+}
+
+function normalize(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\bnok\b/g, "")
+    .replace(/[^a-zæøå0-9]/g, "");
+}
+
+// Weight for a held fund, matched by normalized name. Returns null when the
+// fund is not in the newest report (typically bought after it was published).
+export function weightFor(
+  fundName: string,
+  report: ReportWeights | null,
+): number | null {
+  if (!report) return null;
+  const target = normalize(fundName);
+  for (const w of report.weights) {
+    const source = normalize(w.name);
+    if (source === target || source.includes(target) || target.includes(source)) {
+      return w.weight;
+    }
+  }
+  return null;
+}

--- a/src/lib/nordnet-types.ts
+++ b/src/lib/nordnet-types.ts
@@ -24,6 +24,9 @@ export interface Holding {
   performanceThisYear: number | null;
   performanceOneMonth: number | null;
   performanceThreeYears: number | null;
+  // Published portfolio weight in %, from the newest quarterly report. Null for
+  // funds held but not yet in a report (bought after it was published).
+  weight: number | null;
 }
 
 export interface Trade {
@@ -41,6 +44,9 @@ export interface NordnetData {
   profile: NordnetProfile | null;
   holdings: Holding[];
   trades: Trade[];
+  // Report period the holding weights come from, e.g. "Q4 2025". Null if no
+  // report could be read.
+  weightAsOf: string | null;
 }
 
 export interface SeriesPoint {


### PR DESCRIPTION
Portfolio weights are not exposed by any public Nordnet API. The Forvaltningsgruppen publishes them each quarter in the report PDFs (public/reports).

- Parse the newest quarterly report for the 'Porteføljevekt' lines
- Match to funds Nordnet reports as held: held fund gets its published weight, fund bought after the report shows 'Ny', fund sold since drops off
- New 'Andel' column on the holdings table, labeled with the report period (currently Q4 2025)
- Serverless: report PDFs traced into the /api/nordnet function