### PR TITLE
Enrich holdings with fee, benchmark, ESG and rating

### DIFF
--- a/src/app/api/nordnet/route.ts
+++ b/src/app/api/nordnet/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getProfile, getTrades, getHoldings } from "@/lib/nordnet";
-import { getReportWeights, weightFor } from "@/lib/fordeling";
+import { getReportData, reportFundFor } from "@/lib/fordeling";
 
 export const revalidate = 1800;
 
@@ -8,17 +8,22 @@ export async function GET() {
   const [profile, trades, report] = await Promise.all([
     getProfile(),
     getTrades(),
-    getReportWeights(),
+    getReportData(),
   ]);
   const holdings = await getHoldings(trades);
-  const withWeights = holdings.map((h) => ({
-    ...h,
-    weight: weightFor(h.name, report),
-  }));
+  const withReport = holdings.map((h) => {
+    const fund = reportFundFor(h.name, report);
+    return {
+      ...h,
+      weight: fund?.weight ?? null,
+      feePercent: fund?.feePercent ?? null,
+      benchmark: fund?.benchmark ?? null,
+    };
+  });
 
   return NextResponse.json({
     profile,
-    holdings: withWeights,
+    holdings: withReport,
     trades: trades.slice(0, 100),
     weightAsOf: report?.period ?? null,
   });

--- a/src/components/HoldingsTable.tsx
+++ b/src/components/HoldingsTable.tsx
@@ -29,6 +29,44 @@ function Weight({ value }: { value: number | null }) {
   );
 }
 
+function Fee({ value }: { value: number | null }) {
+  if (value === null) return <span className="text-foreground-secondary">-</span>;
+  return (
+    <span className="text-foreground-primary">
+      {value.toFixed(2).replace(".", ",")} %
+    </span>
+  );
+}
+
+// SFDR article: 8 promotes environmental/social traits, 9 targets sustainable
+// investment. Article 6 (no ESG focus) gets no badge.
+function Esg({ article }: { article: number | null }) {
+  if (article !== 8 && article !== 9) return null;
+  const label = article === 9 ? "Bærekraft" : "ESG";
+  return (
+    <span
+      className="inline-block rounded bg-success/15 px-1.5 py-0.5 text-xs font-medium text-success"
+      title={`SFDR artikkel ${article}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function Rating({ value }: { value: number | null }) {
+  if (value === null) return null;
+  return (
+    <span
+      className="text-foreground-secondary"
+      aria-label={`Morningstar ${value} av 5`}
+      title={`Morningstar ${value} av 5`}
+    >
+      {"★".repeat(value)}
+      <span className="opacity-30">{"★".repeat(Math.max(0, 5 - value))}</span>
+    </span>
+  );
+}
+
 export default function HoldingsTable() {
   const { data, isLoading } = useNordnet();
 
@@ -65,6 +103,9 @@ export default function HoldingsTable() {
                 Andel
               </th>
               <th className="text-right py-3 px-4 text-foreground-primary font-semibold">
+                Honorar
+              </th>
+              <th className="text-right py-3 px-4 text-foreground-primary font-semibold">
                 Kurs (NAV)
               </th>
               <th className="text-right py-3 px-4 text-foreground-primary font-semibold">
@@ -72,9 +113,6 @@ export default function HoldingsTable() {
               </th>
               <th className="text-right py-3 px-4 text-foreground-primary font-semibold">
                 3 år
-              </th>
-              <th className="text-left py-3 px-4 text-foreground-primary font-semibold">
-                Kategori
               </th>
             </tr>
           </thead>
@@ -92,14 +130,26 @@ export default function HoldingsTable() {
                         alt=""
                         width={24}
                         height={24}
-                        className="w-6 h-6 rounded object-contain"
+                        className="w-6 h-6 rounded object-contain shrink-0"
                       />
                     )}
-                    <span>{h.name}</span>
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                        <span>{h.name}</span>
+                        <Rating value={h.rating} />
+                        <Esg article={h.esgArticle} />
+                      </div>
+                      <p className="text-xs text-foreground-secondary">
+                        {h.benchmark ?? h.category ?? ""}
+                      </p>
+                    </div>
                   </div>
                 </td>
                 <td className="py-3 px-4 text-right whitespace-nowrap">
                   <Weight value={h.weight} />
+                </td>
+                <td className="py-3 px-4 text-right whitespace-nowrap">
+                  <Fee value={h.feePercent} />
                 </td>
                 <td className="py-3 px-4 text-right text-foreground-secondary whitespace-nowrap">
                   {h.nav !== null
@@ -115,9 +165,6 @@ export default function HoldingsTable() {
                 <td className="py-3 px-4 text-right whitespace-nowrap">
                   <Pct value={h.performanceThreeYears} />
                 </td>
-                <td className="py-3 px-4 text-foreground-secondary">
-                  {h.category ?? "-"}
-                </td>
               </tr>
             ))}
           </tbody>
@@ -126,8 +173,9 @@ export default function HoldingsTable() {
 
       {weightAsOf && (
         <p className="mt-4 text-sm text-foreground-secondary">
-          Andel er publisert porteføljevekt fra rapporten for {weightAsOf}. Fond
-          merket «Ny» er kjøpt etter rapporten og har ingen publisert vekt ennå.
+          Andel, honorar og referanseindeks er hentet fra rapporten for{" "}
+          {weightAsOf}. Rating og ESG kommer fra Nordnet. Fond merket «Ny» er
+          kjøpt etter rapporten og mangler publiserte tall ennå.
         </p>
       )}
     </div>

--- a/src/lib/fordeling.ts
+++ b/src/lib/fordeling.ts
@@ -1,10 +1,12 @@
-// Portfolio weights ("fordeling") are not exposed by any public Nordnet API.
-// The Forvaltningsgruppen publishes them each quarter in the report PDFs under
-// public/reports, one line per fund: "<Fund> - Porteføljevekt: NN,NN %". This
-// reads the newest report, extracts those weights, and matches them to the
-// funds Nordnet currently reports as held. A fund held but not in the report
-// (bought after it was written) has no published weight yet; a fund in the
-// report but no longer held (sold) simply never gets matched.
+// Per-fund facts that are not exposed by any public Nordnet API: the portfolio
+// weight, the management fee, and the benchmark index. The Forvaltningsgruppen
+// publishes all three each quarter in the report PDFs under public/reports, one
+// section per fund headed "<Fund> - Porteføljevekt: NN,NN %" followed by a
+// "Fakta om fondet" table with "Forvaltningshonorar" and "Referanseindeks".
+// This reads the newest report and matches each fund to the funds Nordnet
+// currently reports as held. A held fund missing from the report (bought after
+// it was written) has no published facts yet; a fund sold since the report
+// simply never gets matched.
 
 import fs from "fs";
 import path from "path";
@@ -12,9 +14,16 @@ import { getDocumentProxy, extractText } from "unpdf";
 
 const REPORTS_DIR = path.join(process.cwd(), "public", "reports");
 
-export interface ReportWeights {
+export interface ReportFund {
+  name: string;
+  weight: number;
+  feePercent: number | null;
+  benchmark: string | null;
+}
+
+export interface ReportData {
   period: string;
-  weights: { name: string; weight: number }[];
+  funds: ReportFund[];
 }
 
 interface ReportFile {
@@ -62,25 +71,48 @@ function reportFiles(): ReportFile[] {
   );
 }
 
-function parseWeights(text: string): { name: string; weight: number }[] {
-  // The fund name sits right before "- Porteføljevekt: NN %", anchored to the
-  // preceding sentence end so the description of the previous fund is not
-  // swept into the name.
-  const re =
-    /[.»]\s*([A-ZÆØÅÖ][^–]{2,50}?)\s*[–-]\s*Portef(?:ø|o)ljevekt:\s*(\d+[.,]\d+)\s*%/gi;
+// Each fund heading anchors to the preceding sentence end so the description of
+// the previous fund is not swept into the name.
+const HEADING =
+  /[.»]\s*([A-ZÆØÅÖ][^–]{2,50}?)\s*[–-]\s*Portef(?:ø|o)ljevekt:\s*(\d+[.,]\d+)\s*%/gi;
+
+function parseFunds(text: string): ReportFund[] {
+  const marks: { name: string; weight: number; start: number; end: number }[] =
+    [];
   const seen = new Set<string>();
-  const out: { name: string; weight: number }[] = [];
   let m: RegExpExecArray | null;
-  while ((m = re.exec(text))) {
+  while ((m = HEADING.exec(text))) {
     const name = m[1].trim().replace(/\s+/g, " ");
     if (seen.has(name)) continue;
     seen.add(name);
-    out.push({ name, weight: parseFloat(m[2].replace(",", ".")) });
+    marks.push({
+      name,
+      weight: parseFloat(m[2].replace(",", ".")),
+      start: m.index,
+      end: HEADING.lastIndex,
+    });
   }
-  return out;
+
+  return marks.map((mark, i) => {
+    // The Fakta table sits between this heading and the next one.
+    const block = text.slice(
+      mark.end,
+      i + 1 < marks.length ? marks[i + 1].start : mark.end + 1200,
+    );
+    const fee = block.match(/Forvaltningshonorar\s+(\d+[.,]\d+)\s*%/i);
+    const bench = block.match(
+      /Referanseindeks\s+(.+?)\s+(?:Forvaltningshonorar|Mandat|Fondstype|Periode)/i,
+    );
+    return {
+      name: mark.name,
+      weight: mark.weight,
+      feePercent: fee ? parseFloat(fee[1].replace(",", ".")) : null,
+      benchmark: bench ? bench[1].trim().replace(/\s+/g, " ") : null,
+    };
+  });
 }
 
-async function extractReport(file: string): Promise<ReportWeights | null> {
+async function extractReport(file: string): Promise<ReportFund[] | null> {
   let buf: Buffer;
   try {
     buf = await fs.promises.readFile(path.join(REPORTS_DIR, file));
@@ -89,29 +121,29 @@ async function extractReport(file: string): Promise<ReportWeights | null> {
   }
   const pdf = await getDocumentProxy(new Uint8Array(buf));
   const { text } = await extractText(pdf, { mergePages: true });
-  return { period: "", weights: parseWeights(text) };
+  return parseFunds(text);
 }
 
 // A report is only trusted if it yields a plausible full allocation: enough
 // funds and a total near 100 %. This filters out half-written drafts.
-function isValid(w: { weight: number }[]): boolean {
-  if (w.length < 4) return false;
-  const sum = w.reduce((s, x) => s + x.weight, 0);
+function isValid(funds: ReportFund[]): boolean {
+  if (funds.length < 4) return false;
+  const sum = funds.reduce((s, f) => s + f.weight, 0);
   return sum >= 80 && sum <= 120;
 }
 
-let cache: { key: string; value: ReportWeights | null } | null = null;
+let cache: { key: string; value: ReportData | null } | null = null;
 
-export async function getReportWeights(): Promise<ReportWeights | null> {
+export async function getReportData(): Promise<ReportData | null> {
   const candidates = reportFiles();
   const key = candidates.map((c) => c.file).join("|");
   if (cache && cache.key === key) return cache.value;
 
-  let value: ReportWeights | null = null;
+  let value: ReportData | null = null;
   for (const candidate of candidates) {
-    const report = await extractReport(candidate.file);
-    if (report && isValid(report.weights)) {
-      value = { period: candidate.label, weights: report.weights };
+    const funds = await extractReport(candidate.file);
+    if (funds && isValid(funds)) {
+      value = { period: candidate.label, funds };
       break;
     }
   }
@@ -126,18 +158,18 @@ function normalize(name: string): string {
     .replace(/[^a-zæøå0-9]/g, "");
 }
 
-// Weight for a held fund, matched by normalized name. Returns null when the
+// The report entry for a held fund, matched by normalized name. Null when the
 // fund is not in the newest report (typically bought after it was published).
-export function weightFor(
+export function reportFundFor(
   fundName: string,
-  report: ReportWeights | null,
-): number | null {
-  if (!report) return null;
+  data: ReportData | null,
+): ReportFund | null {
+  if (!data) return null;
   const target = normalize(fundName);
-  for (const w of report.weights) {
-    const source = normalize(w.name);
+  for (const f of data.funds) {
+    const source = normalize(f.name);
     if (source === target || source.includes(target) || target.includes(source)) {
-      return w.weight;
+      return f;
     }
   }
   return null;

--- a/src/lib/nordnet-types.ts
+++ b/src/lib/nordnet-types.ts
@@ -24,9 +24,14 @@ export interface Holding {
   performanceThisYear: number | null;
   performanceOneMonth: number | null;
   performanceThreeYears: number | null;
-  // Published portfolio weight in %, from the newest quarterly report. Null for
-  // funds held but not yet in a report (bought after it was published).
+  // Morningstar rating (1-5) and SFDR article (6/8/9), from Nordnet.
+  rating: number | null;
+  esgArticle: number | null;
+  // Published in the newest quarterly report. Null for funds held but not yet
+  // in a report (bought after it was published).
   weight: number | null;
+  feePercent: number | null;
+  benchmark: string | null;
 }
 
 export interface Trade {

--- a/src/lib/nordnet.ts
+++ b/src/lib/nordnet.ts
@@ -128,6 +128,7 @@ interface InstrumentInfo {
   last_nav?: number;
   last_nav_date?: string;
   rating?: number;
+  sfdr_article?: number;
   institute?: string;
   performance_one_month?: number;
   performance_this_year?: number;
@@ -148,6 +149,8 @@ export interface Holding {
   performanceThisYear: number | null;
   performanceOneMonth: number | null;
   performanceThreeYears: number | null;
+  rating: number | null;
+  esgArticle: number | null;
 }
 
 export async function getHoldings(trades: Trade[]): Promise<Holding[]> {
@@ -180,6 +183,8 @@ export async function getHoldings(trades: Trade[]): Promise<Holding[]> {
         performanceThisYear: i?.performance_this_year ?? null,
         performanceOneMonth: i?.performance_one_month ?? null,
         performanceThreeYears: i?.performance_three_years ?? null,
+        rating: i?.rating ?? null,
+        esgArticle: i?.sfdr_article ?? null,
       };
     }),
   );


### PR DESCRIPTION
Adds per-fund detail to the holdings table.

- Report parser now also extracts each fund's management fee (Forvaltningshonorar) and benchmark (Referanseindeks), alongside the weight
- Morningstar rating and SFDR article (ESG) come from the Nordnet instrument feed
- Table: new Honorar column, benchmark under each fund name, an ESG badge and rating stars
- Fee/benchmark are null for funds bought after the newest report (same as weight); rating/ESG show for every fund
- API management_fee is unreliable (null or contradicts the report), so fees come from the report