### PR TITLE
feat: allocation donut and prospectus links

### DIFF
--- a/src/app/api/nordnet/route.ts
+++ b/src/app/api/nordnet/route.ts
@@ -25,6 +25,7 @@ export async function GET() {
     profile,
     holdings: withReport,
     trades: trades.slice(0, 100),
+    fordeling: report?.funds ?? [],
     weightAsOf: report?.period ?? null,
   });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import ContactBox from "../components/ContactBox";
 import NordnetProfileCard from "../components/NordnetProfileCard";
 import FundPerformanceChart from "../components/FundPerformanceChart";
 import PerformanceBars from "../components/PerformanceBars";
+import AllocationDonut from "../components/AllocationDonut";
 import HoldingsTable from "../components/HoldingsTable";
 import TradesList from "../components/TradesList";
 
@@ -26,7 +27,10 @@ export default function Home() {
             <PerformanceBars />
           </div>
 
-          {/* Market split derived from holdings */}
+          {/* Published allocation from the newest report */}
+          <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+            <AllocationDonut />
+          </div>
 
           {/* Current holdings, live from Nordnet */}
           <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">

--- a/src/components/AllocationDonut.tsx
+++ b/src/components/AllocationDonut.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { useNordnet } from "./NordnetProfileCard";
+import { useTheme } from "@/components/providers/ThemeProvider";
+import type { FordelingFund } from "@/lib/nordnet-types";
+
+// Mid-tone hues that stay legible against both the light and dark card
+// backgrounds. Cycled if there are ever more funds than colors.
+const COLORS = [
+  "#3b82f6",
+  "#10b981",
+  "#f59e0b",
+  "#ef4444",
+  "#8b5cf6",
+  "#ec4899",
+  "#14b8a6",
+  "#f97316",
+  "#6366f1",
+  "#84cc16",
+];
+
+function fmt(weight: number): string {
+  return `${weight.toFixed(2).replace(".", ",")} %`;
+}
+
+function DonutTooltip({
+  active,
+  payload,
+  dark,
+}: {
+  active?: boolean;
+  payload?: { payload: FordelingFund }[];
+  dark: boolean;
+}) {
+  if (!active || !payload?.length) return null;
+  const fund = payload[0].payload;
+  return (
+    <div
+      className="rounded-md border px-3 py-2 text-sm shadow-lg"
+      style={{
+        background: dark ? "#1e222d" : "#ffffff",
+        borderColor: dark ? "#2b2f3a" : "#e5e7eb",
+        color: dark ? "#f3f4f6" : "#111827",
+      }}
+    >
+      <div className="font-medium">{fund.name}</div>
+      <div>{fmt(fund.weight)}</div>
+    </div>
+  );
+}
+
+export default function AllocationDonut() {
+  const { data, isLoading } = useNordnet();
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+
+  if (isLoading) {
+    return (
+      <div className="h-64 rounded-lg bg-cardBackground border border-cardBorder animate-pulse" />
+    );
+  }
+
+  const funds = [...(data?.fordeling ?? [])].sort((a, b) => b.weight - a.weight);
+  if (funds.length === 0) return null;
+  const period = data?.weightAsOf;
+
+  return (
+    <div className="w-full">
+      <h2 className="text-2xl font-semibold text-foreground-primary mb-1">
+        Porteføljefordeling
+      </h2>
+      {period && (
+        <p className="text-sm text-foreground-secondary mb-6">
+          Publiserte vekter fra rapporten for {period}
+        </p>
+      )}
+
+      <div className="flex flex-col md:flex-row md:items-center gap-6">
+        <div
+          className="h-64 w-full md:w-64 shrink-0"
+          role="img"
+          aria-label={`Porteføljefordeling per ${period ?? "siste rapport"}`}
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={funds}
+                dataKey="weight"
+                nameKey="name"
+                innerRadius="58%"
+                outerRadius="90%"
+                paddingAngle={1}
+                stroke="none"
+              >
+                {funds.map((f, i) => (
+                  <Cell key={f.name} fill={COLORS[i % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip content={<DonutTooltip dark={dark} />} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+
+        <ul className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+          {funds.map((f, i) => (
+            <li key={f.name} className="flex items-center gap-2 text-sm">
+              <span
+                className="w-3 h-3 rounded-sm shrink-0"
+                style={{ background: COLORS[i % COLORS.length] }}
+                aria-hidden
+              />
+              <span className="flex-1 min-w-0 truncate text-foreground-primary">
+                {f.name}
+              </span>
+              <span className="text-foreground-secondary tabular-nums">
+                {fmt(f.weight)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HoldingsTable.tsx
+++ b/src/components/HoldingsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { ExternalLink } from "lucide-react";
 import { useNordnet } from "./NordnetProfileCard";
 
 function Pct({ value }: { value: number | null }) {
@@ -142,6 +143,17 @@ export default function HoldingsTable() {
                       <p className="text-xs text-foreground-secondary">
                         {h.benchmark ?? h.category ?? ""}
                       </p>
+                      {h.prospectusUrl && (
+                        <a
+                          href={h.prospectusUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 mt-0.5 text-xs text-accent hover:underline"
+                        >
+                          Prospekt
+                          <ExternalLink className="w-3 h-3" aria-hidden />
+                        </a>
+                      )}
                     </div>
                   </div>
                 </td>

--- a/src/lib/nordnet-types.ts
+++ b/src/lib/nordnet-types.ts
@@ -32,6 +32,18 @@ export interface Holding {
   weight: number | null;
   feePercent: number | null;
   benchmark: string | null;
+  // Link to the fund's Morningstar prospectus/KID document, from Nordnet.
+  prospectusUrl: string | null;
+}
+
+// One fund's line in the newest quarterly report allocation. Unlike Holding,
+// this is the full published portfolio (including funds sold since), so the
+// weights sum to ~100 and can drive an allocation chart.
+export interface FordelingFund {
+  name: string;
+  weight: number;
+  feePercent: number | null;
+  benchmark: string | null;
 }
 
 export interface Trade {
@@ -49,8 +61,11 @@ export interface NordnetData {
   profile: NordnetProfile | null;
   holdings: Holding[];
   trades: Trade[];
-  // Report period the holding weights come from, e.g. "Q4 2025". Null if no
-  // report could be read.
+  // The full published allocation from the newest report, weights summing to
+  // ~100. Empty if no report could be read.
+  fordeling: FordelingFund[];
+  // Report period the weights come from, e.g. "Q4 2025". Null if no report
+  // could be read.
   weightAsOf: string | null;
 }
 

--- a/src/lib/nordnet.ts
+++ b/src/lib/nordnet.ts
@@ -129,6 +129,7 @@ interface InstrumentInfo {
   last_nav_date?: string;
   rating?: number;
   sfdr_article?: number;
+  prospectus_url?: string;
   institute?: string;
   performance_one_month?: number;
   performance_this_year?: number;
@@ -151,6 +152,7 @@ export interface Holding {
   performanceThreeYears: number | null;
   rating: number | null;
   esgArticle: number | null;
+  prospectusUrl: string | null;
 }
 
 export async function getHoldings(trades: Trade[]): Promise<Holding[]> {
@@ -185,6 +187,7 @@ export async function getHoldings(trades: Trade[]): Promise<Holding[]> {
         performanceThreeYears: i?.performance_three_years ?? null,
         rating: i?.rating ?? null,
         esgArticle: i?.sfdr_article ?? null,
+        prospectusUrl: i?.prospectus_url ?? null,
       };
     }),
   );


### PR DESCRIPTION
Two holdings features from the data we already have.

**Allocation donut** (new card on the home page, above Fondets sammensetning): a recharts donut of the published portfolio allocation from the newest quarterly report. Uses the full report allocation (weights sum to ~100, including funds sold since the report) so it is an honest snapshot, labeled with the report period. Theme-aware tooltip and colors; the legend is real text (fund name + weight) for accessibility.

**Prospekt links**: each holding now shows a Prospekt link to its Morningstar prospectus/KID document, from the `prospectus_url` field Nordnet already returns.

API: `/api/nordnet` now returns `fordeling` (the full report allocation) alongside the held-only `holdings`.

Verified live: fordeling = 8 funds, weights sum 100.0, prospectus URL present. tsc, eslint, 33 tests, build all pass.