### PR TITLE
feat: SEO metadata, sitemap, robots and OG image

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Om fondet",
+  description:
+    "Om TIHLDE Fondet: hvordan investeringsfondet forvaltes og hva midlene brukes til.",
 };
 
 export default function About() {

--- a/src/app/apply/page.tsx
+++ b/src/app/apply/page.tsx
@@ -4,6 +4,8 @@ import SoknaderTable from "@/components/SoknaderTable";
 
 export const metadata: Metadata = {
   title: "Søk om støtte",
+  description:
+    "Søk om økonomisk støtte fra TIHLDE Fondet til prosjekter og arrangementer.",
 };
 
 export default function Apply() {

--- a/src/app/apply/skjema/page.tsx
+++ b/src/app/apply/skjema/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Søknadsskjema",
+  description:
+    "Fyll ut søknadsskjemaet for å søke om støtte fra TIHLDE Fondet.",
 };
 
 export default function SkjemaPage() {

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -7,6 +7,8 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Forvaltningsgruppen",
+  description:
+    "Møt Forvaltningsgruppen som forvalter TIHLDE Fondet.",
 };
 
 export default function Group() {

--- a/src/app/group/tidligere/page.tsx
+++ b/src/app/group/tidligere/page.tsx
@@ -7,6 +7,8 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Tidligere medlemmer",
+  description:
+    "Tidligere medlemmer av Forvaltningsgruppen i TIHLDE Fondet.",
 };
 
 export default function PreviousMembers() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,12 +14,21 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://fondet.tihlde.org"),
   title: {
     default: "TIHLDE Fondet",
     template: "%s | TIHLDE Fondet",
   },
   description:
     "TIHLDE-fondet - Forvaltningsgruppen for TIHLDEs investeringsfond",
+  openGraph: {
+    type: "website",
+    locale: "nb_NO",
+    siteName: "TIHLDE Fondet",
+    title: "TIHLDE Fondet",
+    description:
+      "TIHLDE-fondet - Forvaltningsgruppen for TIHLDEs investeringsfond",
+  },
 };
 
 export const dynamic = "force-dynamic";

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "TIHLDE Fondet";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Brand colours from src/styles/globals.css (dark theme).
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          background: "#131722",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 40,
+            fontWeight: 600,
+            color: "#5e9eff",
+            letterSpacing: 2,
+          }}
+        >
+          TIHLDE
+        </div>
+        <div
+          style={{
+            fontSize: 110,
+            fontWeight: 800,
+            color: "#ffffff",
+            marginTop: 8,
+          }}
+        >
+          Fondet
+        </div>
+        <div
+          style={{
+            fontSize: 34,
+            color: "#d1d4dc",
+            marginTop: 24,
+            maxWidth: 900,
+          }}
+        >
+          Forvaltningsgruppen for TIHLDEs investeringsfond
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/src/app/reports/layout.tsx
+++ b/src/app/reports/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Rapporter",
+  description:
+    "Årsrapporter, kvartalsrapporter, strategi og vedtekter for TIHLDE Fondet.",
 };
 
 export default function ReportsLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/api/",
+    },
+    sitemap: "https://fondet.tihlde.org/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+const BASE = "https://fondet.tihlde.org";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const paths = [
+    "",
+    "/about",
+    "/apply",
+    "/apply/skjema",
+    "/group",
+    "/group/tidligere",
+    "/reports",
+  ];
+  return paths.map((path) => ({
+    url: `${BASE}${path}`,
+    changeFrequency: path === "" || path === "/reports" ? "weekly" : "monthly",
+    priority: path === "" ? 1 : 0.7,
+  }));
+}


### PR DESCRIPTION
SEO + link-preview polish (also closes #61).

- Per-page meta descriptions: about, apply, apply/skjema, group, group/tidligere, reports
- `metadataBase` + default Open Graph tags (siteName, locale nb_NO, type website) on the root layout
- Generated 1200x630 Open Graph image (`opengraph-image.tsx`, next/og), on-brand dark card, no external assets
- `sitemap.xml` and `robots.txt` route handlers (robots disallows /api/)

All Vercel-native. tsc, eslint, build pass; opengraph-image, sitemap.xml, robots.txt all compile as routes.