### PR TITLE
chore: gitignore stray sandbox dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,21 @@
 .playwright-mcp/
 CLAUDE.md
 .claude/
+.mcp.json
+
+# editors
+.idea
+.vscode
+
+# stray shell/env dotfiles that leak into the workdir from the sandbox mount
+.bashrc
+.zshrc
+.bash_profile
+.zprofile
+.profile
+.gitconfig
+.gitmodules
+.ripgreprc
 
 # debug
 npm-debug.log*


### PR DESCRIPTION
The workdir surfaces character-device clones of shell/editor dotfiles from the sandbox mount, cluttering `git status`. They were never committed (untracked, no history), so no history rewrite is needed. This ignores them plus `.mcp.json`, `.idea`, `.vscode`.