### PR TITLE
feat: animated key metrics, scroll reveal and gain/loss arrows

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import ContactBox from "../components/ContactBox";
 import NordnetProfileCard from "../components/NordnetProfileCard";
+import KeyMetrics from "../components/KeyMetrics";
 import FundPerformanceChart from "../components/FundPerformanceChart";
 import PerformanceBars from "../components/PerformanceBars";
 import AllocationDonut from "../components/AllocationDonut";
 import HoldingsTable from "../components/HoldingsTable";
 import TradesList from "../components/TradesList";
+import Reveal from "../components/Reveal";
 
 export default function Home() {
   return (
@@ -17,30 +19,43 @@ export default function Home() {
         <div className="w-full max-w-6xl mx-auto space-y-6 px-0 sm:px-0">
           <NordnetProfileCard />
 
+          {/* At-a-glance metrics derived from the live holdings */}
+          <KeyMetrics />
+
           {/* Performance of holdings vs. indexes, live from Nordnet */}
-          <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
-            <FundPerformanceChart />
-          </div>
+          <Reveal>
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+              <FundPerformanceChart />
+            </div>
+          </Reveal>
 
           {/* Return per fund, live from Nordnet */}
-          <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
-            <PerformanceBars />
-          </div>
+          <Reveal>
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+              <PerformanceBars />
+            </div>
+          </Reveal>
 
           {/* Published allocation from the newest report */}
-          <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
-            <AllocationDonut />
-          </div>
+          <Reveal>
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+              <AllocationDonut />
+            </div>
+          </Reveal>
 
           {/* Current holdings, live from Nordnet */}
-          <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
-            <HoldingsTable />
-          </div>
+          <Reveal>
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+              <HoldingsTable />
+            </div>
+          </Reveal>
 
           {/* Recent trades, live from Nordnet */}
-          <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
-            <TradesList />
-          </div>
+          <Reveal>
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+              <TradesList />
+            </div>
+          </Reveal>
 
           <ContactBox />
         </div>

--- a/src/components/HoldingsTable.tsx
+++ b/src/components/HoldingsTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, ArrowUpRight, ArrowDownRight } from "lucide-react";
 import { useNordnet } from "./NordnetProfileCard";
 
 // prospectusUrl comes from Nordnet's API, so guard the anchor against a
@@ -18,10 +18,13 @@ function safeHttpUrl(url: string | null): string | null {
 
 function Pct({ value }: { value: number | null }) {
   if (value === null) return <span>-</span>;
-  const color = value >= 0 ? "text-success" : "text-red-600 dark:text-red-400";
+  const up = value >= 0;
+  const color = up ? "text-success" : "text-red-600 dark:text-red-400";
+  const Arrow = up ? ArrowUpRight : ArrowDownRight;
   return (
-    <span className={color}>
-      {value >= 0 ? "+" : ""}
+    <span className={`inline-flex items-center justify-end gap-0.5 ${color}`}>
+      <Arrow className="w-3.5 h-3.5" aria-hidden />
+      {up ? "+" : ""}
       {value.toFixed(2).replace(".", ",")} %
     </span>
   );

--- a/src/components/KeyMetrics.tsx
+++ b/src/components/KeyMetrics.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { Layers, Star, Leaf, TrendingUp, type LucideIcon } from "lucide-react";
+import { useNordnet } from "./NordnetProfileCard";
+import { useCountUp, useInView } from "@/lib/anim";
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  inView,
+  format,
+  sub,
+  valueClass = "text-foreground-primary",
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: number;
+  inView: boolean;
+  format: (n: number) => string;
+  sub?: string;
+  valueClass?: string;
+}) {
+  const n = useCountUp(value, inView);
+  return (
+    <div className="rounded-lg border border-cardBorder bg-cardBackground p-5 shadow-lg">
+      <div className="flex items-start justify-between">
+        <span
+          className={`text-3xl sm:text-4xl font-extrabold tabular-nums ${valueClass}`}
+        >
+          {format(n)}
+        </span>
+        <Icon className="w-5 h-5 text-accent shrink-0 mt-1" aria-hidden />
+      </div>
+      <div className="mt-2 text-sm font-medium text-foreground-primary">
+        {label}
+      </div>
+      {sub && (
+        <div className="mt-0.5 text-xs text-foreground-secondary truncate">
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function KeyMetrics() {
+  const { data, isLoading } = useNordnet();
+  const [ref, inView] = useInView<HTMLDivElement>();
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-32 rounded-lg bg-cardBackground border border-cardBorder animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const holdings = data?.holdings ?? [];
+  if (holdings.length === 0) return null;
+
+  const ratings = holdings
+    .map((h) => h.rating)
+    .filter((r): r is number => r !== null);
+  const avgRating = ratings.length
+    ? ratings.reduce((a, b) => a + b, 0) / ratings.length
+    : 0;
+
+  const esgCount = holdings.filter(
+    (h) => h.esgArticle === 8 || h.esgArticle === 9,
+  ).length;
+  const esgPct = Math.round((100 * esgCount) / holdings.length);
+
+  const withYtd = holdings.filter((h) => h.performanceThisYear !== null);
+  const best = withYtd.length
+    ? withYtd.reduce((a, b) =>
+        b.performanceThisYear! > a.performanceThisYear! ? b : a,
+      )
+    : null;
+
+  return (
+    <div ref={ref} className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <StatCard
+        icon={Layers}
+        inView={inView}
+        value={holdings.length}
+        format={(n) => Math.round(n).toString()}
+        label="Fond i porteføljen"
+      />
+      <StatCard
+        icon={Star}
+        inView={inView}
+        value={avgRating}
+        format={(n) => n.toFixed(1).replace(".", ",")}
+        label="Snitt Morningstar"
+        sub={`${"★".repeat(Math.round(avgRating))} av 5`}
+      />
+      <StatCard
+        icon={Leaf}
+        inView={inView}
+        value={esgPct}
+        format={(n) => `${Math.round(n)} %`}
+        label="ESG-dekning"
+        sub={`${esgCount} av ${holdings.length} fond`}
+      />
+      {best && best.performanceThisYear !== null && (
+        <StatCard
+          icon={TrendingUp}
+          inView={inView}
+          value={best.performanceThisYear}
+          format={(n) =>
+            `${n >= 0 ? "+" : ""}${n.toFixed(1).replace(".", ",")} %`
+          }
+          label="Best i år"
+          sub={best.name}
+          valueClass={
+            best.performanceThisYear >= 0
+              ? "text-success"
+              : "text-red-600 dark:text-red-400"
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/Reveal.tsx
+++ b/src/components/Reveal.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useInView } from "@/lib/anim";
+
+// Fades and lifts its children into view on first scroll. The motion lives in
+// the .reveal CSS class, which the reduced-motion media query neutralises.
+export default function Reveal({
+  children,
+  delay = 0,
+  className = "",
+}: {
+  children: React.ReactNode;
+  delay?: number;
+  className?: string;
+}) {
+  const [ref, inView] = useInView<HTMLDivElement>();
+  return (
+    <div
+      ref={ref}
+      className={`reveal ${inView ? "in" : ""} ${className}`}
+      style={delay ? { transitionDelay: `${delay}ms` } : undefined}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/lib/anim.ts
+++ b/src/lib/anim.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+// True when the user asked the OS to reduce motion. SSR-safe: starts false and
+// syncs after mount, so the server and first client render agree.
+export function usePrefersReducedMotion(): boolean {
+  const [reduce, setReduce] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduce(mq.matches);
+    const onChange = () => setReduce(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return reduce;
+}
+
+// Fires once when the element first scrolls into view.
+export function useInView<T extends Element>(
+  threshold = 0.2,
+): [RefObject<T>, boolean] {
+  const ref = useRef<T>(null);
+  const [inView, setInView] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          obs.disconnect();
+        }
+      },
+      { threshold },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [threshold]);
+  return [ref, inView];
+}
+
+// Eases a number from 0 to target once `start` is true. Snaps straight to the
+// target when the user prefers reduced motion.
+export function useCountUp(target: number, start: boolean, duration = 1100): number {
+  const reduce = usePrefersReducedMotion();
+  const [value, setValue] = useState(0);
+  const frame = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!start) return;
+    if (reduce) {
+      setValue(target);
+      return;
+    }
+    let t0: number | null = null;
+    const tick = (t: number) => {
+      if (t0 === null) t0 = t;
+      const p = Math.min((t - t0) / duration, 1);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setValue(target * eased);
+      if (p < 1) frame.current = requestAnimationFrame(tick);
+    };
+    frame.current = requestAnimationFrame(tick);
+    return () => {
+      if (frame.current) cancelAnimationFrame(frame.current);
+    };
+  }, [target, start, duration, reduce]);
+
+  return value;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -76,3 +76,27 @@ body {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
+
+/* Scroll-reveal: hidden and lifted until the .in class is toggled in view. */
+.reveal {
+  opacity: 0;
+  transform: translateY(18px);
+  transition:
+    opacity 0.6s ease,
+    transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: opacity, transform;
+}
+
+.reveal.in {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .reveal.in {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
First wow-factor pass on the home page, grounded in fintech-dashboard best practice (metrics at a glance, motion on scroll, colour plus a secondary indicator for gain/loss).

- **Key metrics hero**: fund count, average Morningstar rating, ESG coverage, and best performer this year, all derived from the live holdings and counted up when scrolled into view.
- **Scroll reveal**: home page cards fade and lift in on first view.
- **Gain/loss arrows**: holdings return columns show a direction arrow next to the colour, so up/down reads without colour alone (WCAG-friendly).

All motion honours `prefers-reduced-motion` (the reveal is a CSS class the media query neutralises; count-up snaps to final). Animation primitives in `src/lib/anim.ts`, no new dependencies. tsc, eslint, 33 tests, build pass.