### PR TITLE
feat: scrolling fund ticker with live YTD return

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import ContactBox from "../components/ContactBox";
 import NordnetProfileCard from "../components/NordnetProfileCard";
+import FundTicker from "../components/FundTicker";
 import KeyMetrics from "../components/KeyMetrics";
 import FundPerformanceChart from "../components/FundPerformanceChart";
 import PerformanceBars from "../components/PerformanceBars";
@@ -17,6 +18,9 @@ export default function Home() {
         </div>
 
         <div className="w-full max-w-6xl mx-auto space-y-6 px-0 sm:px-0">
+          {/* Scrolling YTD return per fund, live from Nordnet */}
+          <FundTicker />
+
           <NordnetProfileCard />
 
           {/* At-a-glance metrics derived from the live holdings */}

--- a/src/components/FundTicker.tsx
+++ b/src/components/FundTicker.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { ArrowUpRight, ArrowDownRight } from "lucide-react";
+import { useNordnet } from "./NordnetProfileCard";
+import { usePrefersReducedMotion } from "@/lib/anim";
+
+type Item = { name: string; perf: number };
+
+function Pill({ name, perf }: Item) {
+  const up = perf >= 0;
+  const Arrow = up ? ArrowUpRight : ArrowDownRight;
+  const color = up ? "text-success" : "text-red-600 dark:text-red-400";
+  return (
+    <span className="inline-flex items-center gap-1.5 px-4 text-sm">
+      <span className="text-foreground-primary">{name}</span>
+      <span className={`inline-flex items-center gap-0.5 tabular-nums ${color}`}>
+        <Arrow className="w-3.5 h-3.5" aria-hidden />
+        {up ? "+" : ""}
+        {perf.toFixed(1).replace(".", ",")} %
+      </span>
+      <span className="text-cardBorder" aria-hidden>
+        ·
+      </span>
+    </span>
+  );
+}
+
+export default function FundTicker() {
+  const { data, isLoading } = useNordnet();
+  const reduce = usePrefersReducedMotion();
+
+  if (isLoading) return null;
+
+  const items: Item[] = (data?.holdings ?? [])
+    .filter((h): h is typeof h & { performanceThisYear: number } =>
+      h.performanceThisYear !== null,
+    )
+    .map((h) => ({ name: h.name, perf: h.performanceThisYear }));
+
+  if (items.length === 0) return null;
+
+  const label = "Avkastning hittil i år per fond";
+
+  // Reduced motion: a static, wrapping row instead of a moving marquee.
+  if (reduce) {
+    return (
+      <div
+        className="ticker rounded-lg border border-cardBorder bg-cardBackground/60 py-2"
+        role="marquee"
+        aria-label={label}
+      >
+        <div className="flex flex-wrap justify-center gap-y-1">
+          {items.map((it) => (
+            <Pill key={it.name} {...it} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="ticker overflow-hidden rounded-lg border border-cardBorder bg-cardBackground/60 py-2"
+      role="marquee"
+      aria-label={label}
+    >
+      <div className="ticker-track whitespace-nowrap">
+        {/* Two identical copies so the -50% translate loops seamlessly. */}
+        {[0, 1].map((copy) => (
+          <div key={copy} className="inline-flex" aria-hidden={copy === 1}>
+            {items.map((it) => (
+              <Pill key={it.name} {...it} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -100,3 +100,32 @@ body {
     transition: none;
   }
 }
+
+/* Fund ticker: two stacked copies scroll left, looping at -50%. Pauses on
+   hover or keyboard focus so a value can be read. */
+@keyframes ticker {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.ticker-track {
+  display: inline-flex;
+  min-width: 100%;
+  animation: ticker 45s linear infinite;
+  will-change: transform;
+}
+
+.ticker:hover .ticker-track,
+.ticker:focus-within .ticker-track {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ticker-track {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What

A finance-style ticker strip above the profile card that scrolls each fund's return **this year**, live from Nordnet holdings. Up = green with an up-arrow, down = red with a down-arrow.

## Behaviour

- **Pauses** on hover and keyboard focus so a value can be read.
- Under `prefers-reduced-motion` it renders as a **static wrapping row** instead of a marquee (no motion at all).
- Two stacked copies of the track scroll to -50% for a seamless loop.
- Hidden entirely while loading or when no fund has a YTD figure.

## Accessibility

- `role=marquee` + `aria-label`; the duplicate track copy is `aria-hidden`.
- Arrows are decorative (`aria-hidden`), sign and color carry meaning together, never color alone.

## Checks

tsc clean, eslint clean, 33 tests pass, build succeeds. No new dependencies.