### PR TITLE
feat: live data-freshness indicator under the hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import ContactBox from "../components/ContactBox";
 import NordnetProfileCard from "../components/NordnetProfileCard";
 import FundTicker from "../components/FundTicker";
+import DataFreshness from "../components/DataFreshness";
 import KeyMetrics from "../components/KeyMetrics";
 import FundPerformanceChart from "../components/FundPerformanceChart";
 import PerformanceBars from "../components/PerformanceBars";
@@ -15,6 +16,9 @@ export default function Home() {
       <main className="flex flex-col items-center justify-center sm:px-8 sm:pb-8 pt-24">
         <div className="text-center mb-12 px-4 sm:px-0 pt-8 sm:pt-0">
           <h1 className="text-4xl font-bold text-foreground-primary">Fondet</h1>
+          <div className="mt-3">
+            <DataFreshness />
+          </div>
         </div>
 
         <div className="w-full max-w-6xl mx-auto space-y-6 px-0 sm:px-0">

--- a/src/components/DataFreshness.tsx
+++ b/src/components/DataFreshness.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import type { NordnetData } from "@/lib/nordnet-types";
+
+function relative(fromMs: number, nowMs: number): string {
+  const mins = Math.max(0, Math.floor((nowMs - fromMs) / 60000));
+  if (mins < 1) return "nettopp";
+  if (mins < 60) return `for ${mins} min siden`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `for ${hours} ${hours === 1 ? "time" : "timer"} siden`;
+  const days = Math.floor(hours / 24);
+  return `for ${days} ${days === 1 ? "dag" : "dager"} siden`;
+}
+
+export default function DataFreshness() {
+  // Reads the same cached query as the rest of the page, so no extra fetch.
+  const { dataUpdatedAt, isLoading, isError } = useQuery<NordnetData>({
+    queryKey: ["nordnet"],
+    queryFn: () => fetch("/api/nordnet").then((r) => r.json()),
+    staleTime: 1000 * 60 * 30,
+  });
+
+  // Re-render every 30s so the relative time keeps up without a live clock.
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (isLoading || isError || !dataUpdatedAt || now === null) return null;
+
+  return (
+    <p className="inline-flex items-center gap-2 text-sm text-foreground-secondary">
+      <span className="relative inline-flex h-2.5 w-2.5" aria-hidden>
+        <span className="freshness-ping absolute inline-flex h-full w-full rounded-full bg-success opacity-75" />
+        <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-success" />
+      </span>
+      Live data, oppdatert {relative(dataUpdatedAt, now)}
+    </p>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -129,3 +129,27 @@ body {
     animation: none;
   }
 }
+
+/* Freshness dot: an expanding, fading ring behind a solid dot. */
+@keyframes freshness-ping {
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  75%,
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+.freshness-ping {
+  animation: freshness-ping 2s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .freshness-ping {
+    animation: none;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## What

A pulsing green dot with a relative timestamp (`Live data, oppdatert for N min siden`) under the **Fondet** title. Signals that the numbers on the page are pulled fresh from Nordnet.

## How

- Reads the **same cached** `[nordnet]` query, so no extra network request.
- Uses react-query's `dataUpdatedAt`; re-renders the relative time every 30s.
- Ping ring disabled under `prefers-reduced-motion`; the solid dot stays.
- Hidden while loading, on error, or before the client clock is set (SSR-safe).

## Checks

tsc clean, eslint clean, 33 tests pass, build succeeds. No new dependencies.