### PR TITLE
feat: subtle hover-lift on dashboard cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,35 +32,35 @@ export default function Home() {
 
           {/* Performance of holdings vs. indexes, live from Nordnet */}
           <Reveal>
-            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg card-hover">
               <FundPerformanceChart />
             </div>
           </Reveal>
 
           {/* Return per fund, live from Nordnet */}
           <Reveal>
-            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg card-hover">
               <PerformanceBars />
             </div>
           </Reveal>
 
           {/* Published allocation from the newest report */}
           <Reveal>
-            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg card-hover">
               <AllocationDonut />
             </div>
           </Reveal>
 
           {/* Current holdings, live from Nordnet */}
           <Reveal>
-            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg card-hover">
               <HoldingsTable />
             </div>
           </Reveal>
 
           {/* Recent trades, live from Nordnet */}
           <Reveal>
-            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg card-hover">
               <TradesList />
             </div>
           </Reveal>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -130,6 +130,26 @@ body {
   }
 }
 
+/* Dashboard cards lift a touch on hover for tactile feedback. */
+.card-hover {
+  transition:
+    transform 0.25s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.25s ease;
+}
+
+.card-hover:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 30px -12px rgba(0, 0, 0, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-hover,
+  .card-hover:hover {
+    transform: none;
+    transition: none;
+  }
+}
+
 /* Freshness dot: an expanding, fading ring behind a solid dot. */
 @keyframes freshness-ping {
   0% {


### PR DESCRIPTION
## What

The home-page dashboard cards rise 3px with a softer, larger shadow on hover. Small tactile feedback that makes the dashboard feel responsive to the cursor.

## Notes

- Pure CSS (`.card-hover`), applied to the five chart/table card wrappers.
- `transform` only, so no layout reflow.
- Fully disabled under `prefers-reduced-motion`.

## Checks

eslint clean, build succeeds. No new dependencies.