### PR TITLE
feat: back-to-top button on the dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import ContactBox from "../components/ContactBox";
 import NordnetProfileCard from "../components/NordnetProfileCard";
 import FundTicker from "../components/FundTicker";
 import DataFreshness from "../components/DataFreshness";
+import BackToTop from "../components/BackToTop";
 import KeyMetrics from "../components/KeyMetrics";
 import FundPerformanceChart from "../components/FundPerformanceChart";
 import PerformanceBars from "../components/PerformanceBars";
@@ -68,6 +69,7 @@ export default function Home() {
           <ContactBox />
         </div>
       </main>
+      <BackToTop />
     </div>
   );
 }

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { ArrowUp } from "lucide-react";
+import { useEffect, useState } from "react";
+import { usePrefersReducedMotion } from "@/lib/anim";
+
+// Floating button that appears once the page is scrolled past the first
+// viewport and jumps back to the top.
+export default function BackToTop() {
+  const [show, setShow] = useState(false);
+  const reduce = usePrefersReducedMotion();
+
+  useEffect(() => {
+    const onScroll = () => setShow(window.scrollY > 600);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        window.scrollTo({ top: 0, behavior: reduce ? "auto" : "smooth" })
+      }
+      aria-label="Tilbake til toppen"
+      className="fixed bottom-6 right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full border border-cardBorder bg-cardBackground text-foreground-primary shadow-lg transition-colors hover:bg-cardBorder/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground-primary"
+    >
+      <ArrowUp className="h-5 w-5" aria-hidden />
+    </button>
+  );
+}


### PR DESCRIPTION
## What

A floating button (bottom-right) that appears once the page is scrolled past the first viewport and jumps back to the top. Useful on the long single-page dashboard.

## Accessibility

- 44x44 touch target, `aria-label`, visible focus ring.
- Smooth scroll normally, **instant** jump under `prefers-reduced-motion`.
- Hidden until needed, so it never covers content at the top.

## Checks

tsc clean, eslint clean, build succeeds. No new dependencies.