### PR TITLE
feat: returns matrix heatmap per fund and period

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import KeyMetrics from "../components/KeyMetrics";
 import FundPerformanceChart from "../components/FundPerformanceChart";
 import PerformanceBars from "../components/PerformanceBars";
 import AllocationDonut from "../components/AllocationDonut";
+import ReturnsMatrix from "../components/ReturnsMatrix";
 import HoldingsTable from "../components/HoldingsTable";
 import TradesList from "../components/TradesList";
 import Reveal from "../components/Reveal";
@@ -49,6 +50,13 @@ export default function Home() {
           <Reveal>
             <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg card-hover">
               <AllocationDonut />
+            </div>
+          </Reveal>
+
+          {/* Return per fund across periods, live from Nordnet */}
+          <Reveal>
+            <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg card-hover">
+              <ReturnsMatrix />
             </div>
           </Reveal>
 

--- a/src/components/ReturnsMatrix.tsx
+++ b/src/components/ReturnsMatrix.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useNordnet } from "./NordnetProfileCard";
+import type { Holding } from "@/lib/nordnet-types";
+
+const PERIODS: { key: keyof Holding; label: string }[] = [
+  { key: "performanceOneMonth", label: "1 md" },
+  { key: "performanceThisYear", label: "I år" },
+  { key: "performanceThreeYears", label: "3 år" },
+  { key: "performanceFiveYears", label: "5 år" },
+];
+
+function fmt(v: number): string {
+  return `${v >= 0 ? "+" : ""}${v.toFixed(1).replace(".", ",")} %`;
+}
+
+// Subtle heatmap tint. Text always stays the primary color for contrast; the
+// background only hints at magnitude, capped so it never overpowers the text.
+function tint(v: number): string {
+  const alpha = Math.min(Math.abs(v) / 20, 1) * 0.3;
+  const rgb = v >= 0 ? "16, 163, 74" : "220, 38, 38";
+  return `rgba(${rgb}, ${alpha})`;
+}
+
+export default function ReturnsMatrix() {
+  const { data, isLoading } = useNordnet();
+
+  if (isLoading) {
+    return (
+      <div className="h-64 rounded-lg bg-cardBackground border border-cardBorder animate-pulse" />
+    );
+  }
+
+  const holdings = data?.holdings ?? [];
+  if (holdings.length === 0) return null;
+
+  return (
+    <div className="w-full">
+      <h2 className="text-2xl font-semibold text-foreground-primary mb-1">
+        Avkastning per periode
+      </h2>
+      <p className="text-sm text-foreground-secondary mb-5">
+        Fondenes egne tall fra Nordnet. Farge viser styrke, grønn opp og rød
+        ned.
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm">
+          <caption className="sr-only">
+            Avkastning per fond over 1 måned, i år, 3 år og 5 år
+          </caption>
+          <thead>
+            <tr className="border-b border-cardBorder">
+              <th
+                scope="col"
+                className="py-2 pr-4 text-left font-medium text-foreground-secondary"
+              >
+                Fond
+              </th>
+              {PERIODS.map((p) => (
+                <th
+                  key={p.label}
+                  scope="col"
+                  className="py-2 px-3 text-right font-medium text-foreground-secondary tabular-nums"
+                >
+                  {p.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {holdings.map((h) => (
+              <tr key={h.legacyInstrumentId} className="border-b border-cardBorder/50">
+                <th
+                  scope="row"
+                  className="py-2 pr-4 text-left font-normal text-foreground-primary max-w-[16rem] truncate"
+                >
+                  {h.name}
+                </th>
+                {PERIODS.map((p) => {
+                  const v = h[p.key] as number | null;
+                  return (
+                    <td
+                      key={p.label}
+                      className="py-2 px-3 text-right tabular-nums text-foreground-primary"
+                      style={v !== null ? { background: tint(v) } : undefined}
+                    >
+                      {v !== null ? (
+                        fmt(v)
+                      ) : (
+                        <span className="text-foreground-secondary">–</span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/nordnet-types.ts
+++ b/src/lib/nordnet-types.ts
@@ -24,6 +24,7 @@ export interface Holding {
   performanceThisYear: number | null;
   performanceOneMonth: number | null;
   performanceThreeYears: number | null;
+  performanceFiveYears: number | null;
   // Morningstar rating (1-5) and SFDR article (6/8/9), from Nordnet.
   rating: number | null;
   esgArticle: number | null;

--- a/src/lib/nordnet.ts
+++ b/src/lib/nordnet.ts
@@ -150,6 +150,7 @@ export interface Holding {
   performanceThisYear: number | null;
   performanceOneMonth: number | null;
   performanceThreeYears: number | null;
+  performanceFiveYears: number | null;
   rating: number | null;
   esgArticle: number | null;
   prospectusUrl: string | null;
@@ -185,6 +186,7 @@ export async function getHoldings(trades: Trade[]): Promise<Holding[]> {
         performanceThisYear: i?.performance_this_year ?? null,
         performanceOneMonth: i?.performance_one_month ?? null,
         performanceThreeYears: i?.performance_three_years ?? null,
+        performanceFiveYears: i?.performance_five_years ?? null,
         rating: i?.rating ?? null,
         esgArticle: i?.sfdr_article ?? null,
         prospectusUrl: i?.prospectus_url ?? null,


### PR DESCRIPTION
## What

A **returns matrix** card: every held fund by **1 md / I år / 3 år / 5 år**, using each fund's own figures from Nordnet.

Cells carry a subtle green/red heatmap tint scaled by magnitude (capped at 30% alpha), with the value in text so meaning is never color-only. Missing figures show an en-dash.

## Data

Wires the five-year return (`performance_five_years`) through the instrument payload to the holding; 1M / YTD / 3Y were already mapped. No fabricated values, missing periods render blank.

## Accessibility

- Real `<table>` with `scope=col` period headers and `scope=row` fund names, sr-only caption.
- Text carries the number; tint is decorative and low-alpha, so contrast holds in both themes.
- Horizontal scroll on narrow screens.

## Checks

tsc clean, eslint clean, 33 tests pass, build succeeds. No new dependencies.