### PR TITLE
feat: magic-link login for forvaltere

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tanstack/react-query": "^5.90.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jose": "^6.2.3",
         "lightweight-charts": "^5.2.0",
         "lucide-react": "^0.548.0",
         "next": "^14.2.32",
@@ -5725,6 +5726,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-query": "^5.90.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jose": "^6.2.3",
     "lightweight-charts": "^5.2.0",
     "lucide-react": "^0.548.0",
     "next": "^14.2.32",

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const inputClass =
+  "w-full px-4 py-3 bg-background border border-cardBorder rounded-lg text-foreground-primary placeholder:text-foreground-secondary focus:outline-none focus:border-blue-500 transition";
+
+export default function AdminLoginPage() {
+  const [email, setEmail] = useState("");
+  const [sending, setSending] = useState(false);
+  const [message, setMessage] = useState("");
+  const [linkError, setLinkError] = useState(false);
+
+  useEffect(() => {
+    setLinkError(
+      new URLSearchParams(window.location.search).get("feil") === "ugyldig",
+    );
+  }, []);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setSending(true);
+    setLinkError(false);
+    try {
+      const res = await fetch("/api/auth/request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      setMessage(data.message);
+    } catch {
+      setMessage("Noe gikk galt. Prøv igjen.");
+    }
+    setSending(false);
+  }
+
+  return (
+    <main className="w-full min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-md bg-cardBackground border border-cardBorder rounded-lg p-6 sm:p-8 shadow-lg">
+        <h1 className="text-2xl font-bold text-foreground-primary mb-2">
+          Logg inn
+        </h1>
+        <p className="text-foreground-secondary mb-6">
+          Kun for forvaltere. Du får en innloggingslenke på e-post.
+        </p>
+        {linkError && (
+          <p role="alert" className="text-red-500 mb-4">
+            Lenken er ugyldig eller utløpt. Be om en ny.
+          </p>
+        )}
+        {message ? (
+          <p role="status" className="text-foreground-primary">
+            {message}
+          </p>
+        ) : (
+          <form onSubmit={submit} noValidate={false}>
+            <label
+              htmlFor="admin-email"
+              className="block text-sm font-semibold text-foreground-primary mb-1"
+            >
+              E-postadresse
+            </label>
+            <input
+              id="admin-email"
+              type="email"
+              required
+              autoComplete="email"
+              placeholder="navn@tihlde.org"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={inputClass}
+            />
+            <button
+              type="submit"
+              disabled={sending}
+              className="mt-4 w-full min-h-[44px] px-4 py-3 rounded-lg bg-button-background text-button-foreground border border-button-border font-semibold hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition disabled:opacity-40"
+            >
+              {sending ? "Sender ..." : "Send innloggingslenke"}
+            </button>
+          </form>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/auth/callback/route.test.ts
+++ b/src/app/api/auth/callback/route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { GET } from "./route";
+import { createToken, SESSION_COOKIE } from "@/lib/auth-token";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "auth-callback-"));
+  process.env.DATA_DIR = tmp;
+  process.env.AUTH_SECRET = "test-secret-for-vitest";
+});
+
+afterEach(() => {
+  delete process.env.DATA_DIR;
+  delete process.env.AUTH_SECRET;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeAdmins(list: string[]) {
+  fs.writeFileSync(path.join(tmp, "admins.json"), JSON.stringify(list));
+}
+
+function get(token: string) {
+  return GET(
+    new Request(
+      `http://localhost:3000/api/auth/callback?token=${encodeURIComponent(token)}`,
+    ),
+  );
+}
+
+describe("GET /api/auth/callback", () => {
+  it("sets a session cookie and redirects to /admin for a valid link", async () => {
+    writeAdmins(["gyldig@tihlde.org"]);
+    const token = await createToken("gyldig@tihlde.org", "login");
+    const res = await get(token);
+    expect(res.headers.get("location")).toContain("/admin");
+    expect(res.headers.get("location")).not.toContain("feil");
+    const cookie = res.headers.get("set-cookie") ?? "";
+    expect(cookie).toContain(`${SESSION_COOKIE}=`);
+    expect(cookie.toLowerCase()).toContain("httponly");
+    expect(cookie.toLowerCase()).toContain("samesite=lax");
+  });
+
+  it("rejects a garbage token", async () => {
+    const res = await get("garbage");
+    expect(res.headers.get("location")).toContain("feil=ugyldig");
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("rejects a session token pasted into the callback", async () => {
+    writeAdmins(["gyldig@tihlde.org"]);
+    const token = await createToken("gyldig@tihlde.org", "session");
+    const res = await get(token);
+    expect(res.headers.get("location")).toContain("feil=ugyldig");
+  });
+
+  it("rejects when the address was removed from the allowlist", async () => {
+    writeAdmins(["fjernet@tihlde.org"]);
+    const token = await createToken("fjernet@tihlde.org", "login");
+    writeAdmins([]);
+    const res = await get(token);
+    expect(res.headers.get("location")).toContain("feil=ugyldig");
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+});

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import {
+  SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  createToken,
+  verifyToken,
+} from "@/lib/auth-token";
+import { isAllowedEmail } from "@/lib/allowlist";
+
+export async function GET(request: Request) {
+  const token = new URL(request.url).searchParams.get("token") ?? "";
+  const email = await verifyToken(token, "login");
+  // Re-check the allowlist: the address may have been removed between the
+  // mail being sent and the link being clicked.
+  if (!email || !isAllowedEmail(email)) {
+    return NextResponse.redirect(new URL("/admin/login?feil=ugyldig", request.url));
+  }
+  const session = await createToken(email, "session");
+  const res = NextResponse.redirect(new URL("/admin", request.url));
+  res.cookies.set(SESSION_COOKIE, session, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+  });
+  return res;
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { SESSION_COOKIE } from "@/lib/auth-token";
+
+export async function POST(request: Request) {
+  const res = NextResponse.redirect(new URL("/", request.url), 303);
+  res.cookies.set(SESSION_COOKIE, "", { path: "/", maxAge: 0 });
+  return res;
+}

--- a/src/app/api/auth/request/route.test.ts
+++ b/src/app/api/auth/request/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { POST } from "./route";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "auth-request-"));
+  process.env.DATA_DIR = tmp;
+  process.env.AUTH_SECRET = "test-secret-for-vitest";
+  delete process.env.RESEND_API_KEY;
+});
+
+afterEach(() => {
+  delete process.env.DATA_DIR;
+  delete process.env.AUTH_SECRET;
+  fs.rmSync(tmp, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function writeAdmins(list: string[]) {
+  fs.writeFileSync(path.join(tmp, "admins.json"), JSON.stringify(list));
+}
+
+function post(body: unknown) {
+  return POST(
+    new Request("http://localhost:3000/api/auth/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/auth/request", () => {
+  it("answers identically for allowed and unknown addresses", async () => {
+    writeAdmins(["kjent@tihlde.org"]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const allowed = await (await post({ email: "kjent@tihlde.org" })).json();
+    const unknown = await (await post({ email: "ukjent@tihlde.org" })).json();
+    const badDomain = await (await post({ email: "kjent@gmail.com" })).json();
+    expect(unknown).toEqual(allowed);
+    expect(badDomain).toEqual(allowed);
+    // but only the allowed one got a link (console fallback without Resend)
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0].join(" ")).toContain("kjent@tihlde.org");
+  });
+
+  it("puts a signed token in the link", async () => {
+    writeAdmins(["lenke@tihlde.org"]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await post({ email: "lenke@tihlde.org" });
+    const line = log.mock.calls[0].join(" ");
+    expect(line).toMatch(/\/api\/auth\/callback\?token=/);
+  });
+
+  it("enforces the per-email cooldown", async () => {
+    writeAdmins(["ivrig@tihlde.org"]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await post({ email: "ivrig@tihlde.org" });
+    await post({ email: "ivrig@tihlde.org" });
+    expect(log).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles a malformed body", async () => {
+    const res = await POST(
+      new Request("http://localhost:3000/api/auth/request", {
+        method: "POST",
+        body: "not json",
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/auth/request/route.ts
+++ b/src/app/api/auth/request/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { createToken } from "@/lib/auth-token";
+import { isAllowedEmail, normalizeEmail } from "@/lib/allowlist";
+import { sendLoginEmail } from "@/lib/send-email";
+
+const COOLDOWN_MS = 60_000;
+const lastRequest = new Map<string, number>();
+
+// Same response no matter what, so nobody can probe which addresses are on
+// the admin list.
+const RESPONSE = {
+  message: "Hvis adressen er autorisert, er en innloggingslenke sendt.",
+};
+
+function baseUrl(request: Request): string {
+  const url = new URL(request.url);
+  const proto = request.headers.get("x-forwarded-proto") ?? url.protocol.replace(":", "");
+  return `${proto}://${url.host}`;
+}
+
+export async function POST(request: Request) {
+  let email = "";
+  try {
+    const body = await request.json();
+    email = normalizeEmail(String(body?.email ?? ""));
+  } catch {
+    // malformed body gets the generic response too
+  }
+  if (!email || !isAllowedEmail(email)) return NextResponse.json(RESPONSE);
+
+  const now = Date.now();
+  if (now - (lastRequest.get(email) ?? 0) < COOLDOWN_MS) {
+    return NextResponse.json(RESPONSE);
+  }
+  lastRequest.set(email, now);
+
+  try {
+    const token = await createToken(email, "login");
+    const link = `${baseUrl(request)}/api/auth/callback?token=${encodeURIComponent(token)}`;
+    await sendLoginEmail(email, link);
+  } catch (err) {
+    // still the generic response; the failure is for the server log
+    console.error("[auth] kunne ikke sende innloggingslenke:", err);
+  }
+  return NextResponse.json(RESPONSE);
+}

--- a/src/lib/allowlist.test.ts
+++ b/src/lib/allowlist.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { isAllowedEmail, normalizeEmail } from "./allowlist";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "allowlist-"));
+  process.env.DATA_DIR = tmp;
+  delete process.env.ADMIN_EMAILS;
+});
+
+afterEach(() => {
+  delete process.env.DATA_DIR;
+  delete process.env.ADMIN_EMAILS;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeAdmins(list: string[]) {
+  fs.writeFileSync(path.join(tmp, "admins.json"), JSON.stringify(list));
+}
+
+describe("isAllowedEmail", () => {
+  it("accepts a listed tihlde.org address", () => {
+    writeAdmins(["forvalter@tihlde.org"]);
+    expect(isAllowedEmail("forvalter@tihlde.org")).toBe(true);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    writeAdmins(["Forvalter@TIHLDE.org"]);
+    expect(isAllowedEmail("  FORVALTER@tihlde.ORG ")).toBe(true);
+  });
+
+  it("rejects tihlde.org addresses not on the list", () => {
+    writeAdmins(["forvalter@tihlde.org"]);
+    expect(isAllowedEmail("annen@tihlde.org")).toBe(false);
+  });
+
+  it("rejects other domains even when listed", () => {
+    writeAdmins(["someone@gmail.com"]);
+    expect(isAllowedEmail("someone@gmail.com")).toBe(false);
+  });
+
+  it("rejects lookalike domains", () => {
+    writeAdmins(["a@evil-tihlde.org", "a@tihlde.org.evil.com"]);
+    expect(isAllowedEmail("a@tihlde.org.evil.com")).toBe(false);
+  });
+
+  it("falls back to ADMIN_EMAILS when admins.json is missing", () => {
+    process.env.ADMIN_EMAILS = "en@tihlde.org, To@Tihlde.org";
+    expect(isAllowedEmail("en@tihlde.org")).toBe(true);
+    expect(isAllowedEmail("to@tihlde.org")).toBe(true);
+    expect(isAllowedEmail("tre@tihlde.org")).toBe(false);
+  });
+
+  it("admins.json wins over the env var when both exist", () => {
+    writeAdmins(["fil@tihlde.org"]);
+    process.env.ADMIN_EMAILS = "env@tihlde.org";
+    expect(isAllowedEmail("fil@tihlde.org")).toBe(true);
+    expect(isAllowedEmail("env@tihlde.org")).toBe(false);
+  });
+
+  it("rejects everything when no list exists", () => {
+    expect(isAllowedEmail("forvalter@tihlde.org")).toBe(false);
+  });
+});
+
+describe("normalizeEmail", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeEmail("  A@B.no ")).toBe("a@b.no");
+  });
+});

--- a/src/lib/allowlist.ts
+++ b/src/lib/allowlist.ts
@@ -1,0 +1,31 @@
+// Who may log in to the admin area. Two gates: the address must be a
+// tihlde.org address, and it must be on the admin list. The list lives on the
+// volume as admins.json (editable without a redeploy); if that file does not
+// exist the ADMIN_EMAILS env var (comma-separated) is used instead. Neither
+// is ever committed to the repo.
+
+import { readJson } from "@/lib/data-store";
+
+const DOMAIN = "@tihlde.org";
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function admins(): string[] {
+  try {
+    const list = readJson<string[]>("admins");
+    if (Array.isArray(list)) return list.map(normalizeEmail);
+  } catch {
+    // no admins.json on the volume; fall through to the env var
+  }
+  return (process.env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map(normalizeEmail)
+    .filter(Boolean);
+}
+
+export function isAllowedEmail(email: string): boolean {
+  const norm = normalizeEmail(email);
+  return norm.endsWith(DOMAIN) && admins().includes(norm);
+}

--- a/src/lib/auth-token.test.ts
+++ b/src/lib/auth-token.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createToken, verifyToken } from "./auth-token";
+
+beforeEach(() => {
+  process.env.AUTH_SECRET = "test-secret-for-vitest";
+});
+
+afterEach(() => {
+  delete process.env.AUTH_SECRET;
+  vi.useRealTimers();
+});
+
+describe("auth tokens", () => {
+  it("round-trips a login token", async () => {
+    const token = await createToken("a@tihlde.org", "login");
+    expect(await verifyToken(token, "login")).toBe("a@tihlde.org");
+  });
+
+  it("rejects a login token used as session and vice versa", async () => {
+    const login = await createToken("a@tihlde.org", "login");
+    const session = await createToken("a@tihlde.org", "session");
+    expect(await verifyToken(login, "session")).toBeNull();
+    expect(await verifyToken(session, "login")).toBeNull();
+  });
+
+  it("rejects an expired login token", async () => {
+    vi.useFakeTimers();
+    const token = await createToken("a@tihlde.org", "login");
+    vi.setSystemTime(Date.now() + 16 * 60 * 1000);
+    expect(await verifyToken(token, "login")).toBeNull();
+  });
+
+  it("accepts a session token within 7 days but not after", async () => {
+    vi.useFakeTimers();
+    const token = await createToken("a@tihlde.org", "session");
+    vi.setSystemTime(Date.now() + 6 * 24 * 60 * 60 * 1000);
+    expect(await verifyToken(token, "session")).toBe("a@tihlde.org");
+    vi.setSystemTime(Date.now() + 2 * 24 * 60 * 60 * 1000);
+    expect(await verifyToken(token, "session")).toBeNull();
+  });
+
+  it("rejects a tampered token", async () => {
+    const token = await createToken("a@tihlde.org", "login");
+    const parts = token.split(".");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+    payload.email = "b@tihlde.org";
+    parts[1] = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    expect(await verifyToken(parts.join("."), "login")).toBeNull();
+  });
+
+  it("rejects a token signed with a different secret", async () => {
+    const token = await createToken("a@tihlde.org", "login");
+    process.env.AUTH_SECRET = "some-other-secret";
+    expect(await verifyToken(token, "login")).toBeNull();
+  });
+
+  it("verify returns null instead of throwing when AUTH_SECRET is unset", async () => {
+    const token = await createToken("a@tihlde.org", "login");
+    delete process.env.AUTH_SECRET;
+    expect(await verifyToken(token, "login")).toBeNull();
+  });
+});

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,0 +1,49 @@
+// Stateless auth tokens, edge-safe (no fs, runs in middleware too). Two uses:
+// "login" is the short-lived magic-link token, "session" the cookie set after
+// the link is clicked. Both are HS256 JWTs signed with AUTH_SECRET, so a
+// login token can never be replayed as a session and vice versa.
+
+import { SignJWT, jwtVerify } from "jose";
+
+const ISSUER = "fondet";
+
+export const SESSION_COOKIE = "fondet_session";
+export const SESSION_MAX_AGE = 7 * 24 * 60 * 60;
+
+export type TokenType = "login" | "session";
+
+const TTL: Record<TokenType, string> = { login: "15m", session: "7d" };
+
+function secretKey(): Uint8Array {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) throw new Error("AUTH_SECRET is not set");
+  return new TextEncoder().encode(secret);
+}
+
+export async function createToken(
+  email: string,
+  type: TokenType,
+): Promise<string> {
+  return new SignJWT({ email, use: type })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(ISSUER)
+    .setIssuedAt()
+    .setExpirationTime(TTL[type])
+    .sign(secretKey());
+}
+
+// Returns the email, or null on any failure (bad signature, expired, wrong
+// type, missing AUTH_SECRET). Never throws: middleware treats null as
+// "not logged in".
+export async function verifyToken(
+  token: string,
+  type: TokenType,
+): Promise<string | null> {
+  try {
+    const { payload } = await jwtVerify(token, secretKey(), { issuer: ISSUER });
+    if (payload.use !== type || typeof payload.email !== "string") return null;
+    return payload.email;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/require-admin.ts
+++ b/src/lib/require-admin.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from "next/server";
+import { SESSION_COOKIE, verifyToken } from "@/lib/auth-token";
+import { isAllowedEmail } from "@/lib/allowlist";
+
+// Gate for the admin API routes. Middleware already guards the /admin pages,
+// but routes re-check here because the allowlist lives on disk and middleware
+// (edge) cannot read it: removing someone from admins.json locks them out
+// immediately instead of when their cookie expires. Non-GET requests must
+// also come from our own origin (cheap CSRF guard on top of SameSite=Lax).
+export async function requireAdmin(
+  request: NextRequest,
+): Promise<string | null> {
+  if (request.method !== "GET") {
+    const origin = request.headers.get("origin");
+    if (origin) {
+      try {
+        if (new URL(origin).host !== request.nextUrl.host) return null;
+      } catch {
+        return null;
+      }
+    }
+  }
+  const token = request.cookies.get(SESSION_COOKIE)?.value ?? "";
+  const email = await verifyToken(token, "session");
+  if (!email || !isAllowedEmail(email)) return null;
+  return email;
+}

--- a/src/lib/send-email.ts
+++ b/src/lib/send-email.ts
@@ -1,0 +1,31 @@
+import { Resend } from "resend";
+
+// Sends the magic link. Without RESEND_API_KEY the link is printed to the
+// server console instead (local dev), except in production where a missing
+// key is a real error.
+export async function sendLoginEmail(email: string, url: string): Promise<void> {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("RESEND_API_KEY is not set");
+    }
+    console.log(`[auth] innloggingslenke for ${email}: ${url}`);
+    return;
+  }
+  const resend = new Resend(key);
+  const { error } = await resend.emails.send({
+    from: "TIHLDE Fondet <fondet@tihlde.org>",
+    to: email,
+    subject: "Innlogging til TIHLDE Fondet",
+    text: [
+      "Hei,",
+      "",
+      "Bruk denne lenken for å logge inn på TIHLDE Fondet. Den er gyldig i 15 minutter:",
+      "",
+      url,
+      "",
+      "Hvis du ikke ba om denne e-posten, kan du se bort fra den.",
+    ].join("\n"),
+  });
+  if (error) throw new Error(error.message);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { SESSION_COOKIE, verifyToken } from "@/lib/auth-token";
+
+// Page gate for the admin area. The allowlist re-check happens in the API
+// routes (requireAdmin); this edge middleware only verifies the session
+// cookie, since it cannot read files.
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  if (pathname === "/admin/login") return NextResponse.next();
+  const token = request.cookies.get(SESSION_COOKIE)?.value ?? "";
+  const email = token ? await verifyToken(token, "session") : null;
+  if (!email) {
+    return NextResponse.redirect(new URL("/admin/login", request.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/admin/:path*"],
+};


### PR DESCRIPTION
## What

- POST /api/auth/request: domain check (@tihlde.org) + admin allowlist (volume data/admins.json, ADMIN_EMAILS env fallback), then mails a 15 minute jose login token via Resend. Without RESEND_API_KEY the link is logged to the server console (dev). Identical response for unknown addresses, 60s per-email cooldown.
- GET /api/auth/callback: verifies the token, re-checks the allowlist, sets a 7 day httpOnly+Secure+SameSite=Lax session cookie, redirects to /admin.
- POST /api/auth/logout clears the cookie.
- src/middleware.ts guards /admin/* (edge, jose). requireAdmin() helper for the coming admin API routes: session + allowlist re-read + Origin check on writes.
- /admin/login page in Norwegian using existing design tokens.

## Env

AUTH_SECRET (required), ADMIN_EMAILS or data/admins.json. Documented in the ops PR.

## Tests

65 vitest green (auth-token, allowlist, request/callback routes new). Manual smoke: full flow request -> console link -> callback -> cookie -> /admin passes middleware; anonymous /admin 307s to login.