### PR TITLE
feat: structural skeleton loading for the dashboard

### DIFF
--- a/src/components/AllocationDonut.tsx
+++ b/src/components/AllocationDonut.tsx
@@ -3,6 +3,7 @@
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
 import { useNordnet } from "./NordnetProfileCard";
 import { useTheme } from "@/components/providers/ThemeProvider";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { FordelingFund } from "@/lib/nordnet-types";
 
 // Mid-tone hues that stay legible against both the light and dark card
@@ -57,7 +58,24 @@ export default function AllocationDonut() {
 
   if (isLoading) {
     return (
-      <div className="h-64 rounded-lg bg-cardBackground border border-cardBorder animate-pulse" />
+      <div className="w-full">
+        <Skeleton className="h-8 w-64 max-w-full mb-2" />
+        <Skeleton className="h-4 w-72 max-w-full mb-6" />
+        <div className="flex flex-col md:flex-row md:items-center gap-6">
+          <div className="h-64 w-full md:w-64 shrink-0 flex items-center justify-center">
+            <Skeleton className="h-56 w-56 rounded-full" />
+          </div>
+          <div className="flex-1 space-y-3">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton className="w-3 h-3 rounded-sm shrink-0" />
+                <Skeleton className="h-4 flex-1 max-w-64" />
+                <Skeleton className="h-4 w-12" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
     );
   }
 

--- a/src/components/HoldingsTable.tsx
+++ b/src/components/HoldingsTable.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { useNordnet } from "./NordnetProfileCard";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { Holding } from "@/lib/nordnet-types";
 
 type SortKey = "name" | "weight" | "fee" | "nav" | "year" | "three";
@@ -164,7 +165,34 @@ export default function HoldingsTable() {
 
   if (isLoading) {
     return (
-      <div className="h-64 rounded-lg bg-cardBackground border border-cardBorder animate-pulse" />
+      <div className="w-full">
+        <Skeleton className="h-8 w-64 max-w-full mb-6" />
+        <div className="border-b border-cardBorder pb-3 mb-1 flex justify-between gap-4">
+          <Skeleton className="h-4 w-24" />
+          <div className="hidden sm:flex gap-8">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        </div>
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 py-4 border-b border-cardBorder/50"
+          >
+            <Skeleton className="w-6 h-6 rounded shrink-0" />
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <Skeleton className="h-4 w-56 max-w-full" />
+              <Skeleton className="h-3 w-36 max-w-full" />
+            </div>
+            <div className="hidden sm:flex gap-8">
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-12" />
+            </div>
+          </div>
+        ))}
+      </div>
     );
   }
 

--- a/src/components/KeyMetrics.tsx
+++ b/src/components/KeyMetrics.tsx
@@ -3,6 +3,7 @@
 import { Layers, Star, Leaf, TrendingUp, type LucideIcon } from "lucide-react";
 import { useNordnet } from "./NordnetProfileCard";
 import { useCountUp, useInView } from "@/lib/anim";
+import { Skeleton } from "@/components/ui/skeleton";
 
 function StatCard({
   icon: Icon,
@@ -54,8 +55,15 @@ export default function KeyMetrics() {
         {[0, 1, 2, 3].map((i) => (
           <div
             key={i}
-            className="h-32 rounded-lg bg-cardBackground border border-cardBorder animate-pulse"
-          />
+            className="rounded-lg border border-cardBorder bg-cardBackground p-5 shadow-lg"
+          >
+            <div className="flex items-start justify-between">
+              <Skeleton className="h-9 sm:h-10 w-20" />
+              <Skeleton className="w-5 h-5 rounded-full mt-1" />
+            </div>
+            <Skeleton className="mt-3 h-4 w-28 max-w-full" />
+            <Skeleton className="mt-2 h-3 w-20" />
+          </div>
         ))}
       </div>
     );

--- a/src/components/NordnetProfileCard.tsx
+++ b/src/components/NordnetProfileCard.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useQuery } from "@tanstack/react-query";
 import { ExternalLink } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { NordnetData } from "@/lib/nordnet-types";
 
 const NORDNET_PROFILE_URL =
@@ -21,7 +22,15 @@ export default function NordnetProfileCard() {
 
   if (isLoading) {
     return (
-      <div className="h-24 rounded-lg bg-cardBackground border border-cardBorder animate-pulse" />
+      <div className="bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg">
+        <div className="flex items-center gap-4">
+          <Skeleton className="w-16 h-16 rounded-full shrink-0" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-6 w-48 max-w-full" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+        </div>
+      </div>
     );
   }
 

--- a/src/components/ReturnsMatrix.tsx
+++ b/src/components/ReturnsMatrix.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useNordnet } from "./NordnetProfileCard";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { Holding } from "@/lib/nordnet-types";
 
 const PERIODS: { key: keyof Holding; label: string }[] = [
@@ -19,7 +20,24 @@ export default function ReturnsMatrix() {
 
   if (isLoading) {
     return (
-      <div className="h-64 rounded-lg bg-cardBackground border border-cardBorder animate-pulse" />
+      <div className="w-full">
+        <Skeleton className="h-8 w-72 max-w-full mb-2" />
+        <Skeleton className="h-4 w-52 max-w-full mb-6" />
+        <Skeleton className="h-2 w-full rounded-full mb-6" />
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between gap-4 py-3 border-b border-cardBorder/50"
+          >
+            <Skeleton className="h-4 w-48 max-w-full" />
+            <div className="flex gap-6 shrink-0">
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="hidden sm:block h-4 w-12" />
+            </div>
+          </div>
+        ))}
+      </div>
     );
   }
 

--- a/src/components/TradesList.tsx
+++ b/src/components/TradesList.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { useNordnet } from "./NordnetProfileCard";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const PAGE_SIZE = 10;
 
@@ -20,7 +21,22 @@ export default function TradesList() {
 
   if (isLoading) {
     return (
-      <div className="h-48 rounded-lg bg-cardBackground border border-cardBorder animate-pulse" />
+      <div className="w-full">
+        <Skeleton className="h-8 w-48 max-w-full mb-6" />
+        <ul className="divide-y divide-cardBorder">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <li key={i} className="py-3">
+              <div className="flex items-center gap-3">
+                <Skeleton className="w-6 h-6 rounded shrink-0" />
+                <Skeleton className="h-4 flex-1 max-w-72" />
+                <Skeleton className="h-4 w-10" />
+                <Skeleton className="hidden sm:block h-4 w-20" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
     );
   }
 

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-slate-400", className)}
+      className={cn("animate-pulse rounded-md bg-cardBorder/60", className)}
       {...props}
     />
   )


### PR DESCRIPTION
Replaces the flat pulsing boxes with skeletons shaped like the content they stand in for:

- Profile card: avatar circle plus two text lines
- Key metrics: four stat card shapes with value, icon and label bars
- Holdings table: heading, column header row and six data rows
- Returns matrix: heading, breadth bar and period rows
- Trades list: five rows with logo, name, type, price and date slots
- Allocation: donut ring with a five-line legend

Layout no longer jumps when data arrives, since the skeletons occupy the same structure the real content will. The Skeleton primitive also swaps its hardcoded bg-slate-400 for the cardBorder token so it renders correctly in both themes.

Verified: tsc clean, eslint clean, 41 tests pass, production build succeeds.