### PR TITLE
docs and search: developer README, changelog, fuzzy palette, deeper trade feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# CHANGELOG
+
+## Tegnforklaring
+
+### ✨ - Ny funksjonalitet
+
+### ⚡ - Forbedret funksjonalitet
+
+### 🦟 - Fikset en bug
+
+### 🎨 - Designendringer
+
+---
+
+## Neste versjon
+
+## Versjon 2026.07.17
+- ⚡ **Hurtigsøk**. Søket (⌘K / Ctrl+K) bruker nå fuzzy-matching med rangering og utheving av treff, grupperer sider og temavalg, og har et ugjennomsiktig panel som ikke lenger lekker sideinnholdet bak seg.
+- ✨ **Kommandopalett**. Åpne søk med ⌘K / Ctrl+K for å hoppe mellom sider og bytte tema.
+- ✨ **Beholdningstabell**. Radene kan sorteres på kolonne og utvides for detaljer om hvert fond.
+- ✨ **Avkastningsmatrise**. Avkastning per fond og periode vises i egen tabell, farget etter fortegn i stedet for fargede bokser.
+- ✨ **Porteføljebredde**. Ny stolpe i avkastningskortet viser hvor mange fond som er i pluss.
+- ✨ **Fondsticker**. Rullende bånd øverst viser hvert fonds YTD-avkastning, pauser på hover.
+- ✨ **Ferskhetsindikator**. Under toppseksjonen vises når dataene sist ble hentet fra Nordnet.
+- ✨ **Treemap**. Sammensetningen kan ses som treemap farget etter årets avkastning.
+- ✨ **Til toppen**. Knapp som ruller dashbordet tilbake til toppen.
+- 🎨 **Nøkkeltall**. Tallene teller opp ved innlasting, seksjoner tones inn ved scroll, og gevinst/tap markeres med piler.
+- 🎨 **Kort**. Dashbordkortene løftes et hakk ved hover.
+- 🦟 **Temafarger**. Kort-, knapp- og input-bakgrunner ble borte fordi camelCase-fargeklassene ikke lagde CSS i Tailwind v4. Alias er lagt til så bakgrunnene rendrer igjen.
+- 🦟 **Mobilmeny**. Menyen er nå ugjennomsiktig når den er åpen, så innholdet bak ikke skinner gjennom.
+- 🎨 **Bidra-lenke**. Footeren lenker nå til kildekoden på GitHub.
+- ⚡ **Dokumentasjon**. README er skrevet om for utviklere: arkitekturvalg med begrunnelse, datakilder, begrensninger og en Tailwind v4-felle.
+
+## Versjon 2026.07.16
+- ✨ **Sammenligningsgraf**. Utviklingsgrafen kan sammenlignes med verdensindekser, og har indikatorer og tegneverktøy.
+- 🦟 **Bilder på Vercel**. Medlems- og gruppebilder rendrer nå også i serverless-miljø.
+- ⚡ **Medlemsliste**. Oppdatert forvaltningsgruppe og nytt navn på søknadsseksjonen.
+
+## Versjon 2026.07.15
+- ✨ **Kvartalsrapporter 2025**. Publisert på /reports.
+- ✨ **Grafverktøy**. La til analyseverktøy, indekser og «tøm alt» i grafen.
+- ✨ **Tidligere medlemmer**. Årsmerket gruppekarusell og paginert liste.
+- ✨ **Volumbilder**. Medlemsbilder serveres fra et montert volum i produksjon, ikke fra repoet.
+- 🦟 **Portretter**. Rettet feilmerkede portretter fra fotoseansene.
+- 🦟 **Graf**. Herdet forhåndsvisningen mot crosshair-rekursjon; beholder fullskjerm når Esc avbryter et tegneverktøy.
+
+## Versjon 2026.07.14
+- ✨ **Live portefølje**. Viser fondets beholdning direkte fra den offentlige Nordnet Shareville-profilen.
+- ✨ **Søknadsskjema**. Egen side med validering i sanntid, sendt som e-post via Resend.
+- ✨ **Rapportside**. /reports med årsrapport som PDF.
+- ✨ **Medlemskort**. Portretter, studie og periode på hvert kort, med roterende gruppebilde.
+- ✨ **Tidligere søknader**. Paginert liste med én rad per søknad og vedtak.
+- 🎨 **Tilgjengelighet**. Kontrast, berøringsmål, fokusmarkering og sidetitler ryddet opp.
+- 🦟 **Content-API**. Fjernet uautentisert PUT og PUT-basert innholdsredigering.
+- ⚡ **Om fondet**. Omskrevet i enklere språk.
+- ⚡ **Arkitektur**. Fjernet adminpanel, innlogging og Firebase-datalag til fordel for offentlig data og filer i repoet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ## Neste versjon
 
+## Versjon 2026.07.18
+- 🎨 **Skjelettlasting**. Plassholderne under lasting speiler nå layouten til innholdet de venter på (profilkort, nøkkeltall, tabeller, donut), så siden ikke hopper når dataene kommer.
+- ⚡ **Handelshistorikk**. Aktivitetsfeeden leses nå 30 sider dypt i stedet for 6, slik at fond kjøpt langt tilbake ikke faller ut av porteføljen.
+- 🦟 **Avhengigheter**. Sikkerhetsoppdatert next, resend, js-yaml og verktøykjeden; 14 av 16 Dependabot-varsler lukket uten major-oppgradering.
+
 ## Versjon 2026.07.17
 - ⚡ **Hurtigsøk**. Søket (⌘K / Ctrl+K) bruker nå fuzzy-matching med rangering og utheving av treff, grupperer sider og temavalg, og har et ugjennomsiktig panel som ikke lenger lekker sideinnholdet bak seg.
 - ✨ **Kommandopalett**. Åpne søk med ⌘K / Ctrl+K for å hoppe mellom sider og bytte tema.

--- a/README.md
+++ b/README.md
@@ -4,25 +4,50 @@ Nettside for TIHLDE sitt investeringsfond. Viser porteføljen live fra fondets
 offentlige Nordnet-profil, medlemmene i forvaltningsgruppen, rapporter og
 søknadsskjema for støtte.
 
-Stack: Next.js (App Router), TypeScript, Tailwind CSS, React Query,
+Dette dokumentet er skrevet for utviklere som skal videreutvikle eller drifte
+siden. Det forklarer ikke bare hva som er bygget, men hvorfor det er bygget
+slik, og hvilke avveininger som ligger bak.
+
+Stack: Next.js 14 (App Router), TypeScript, Tailwind CSS v4, React Query,
 lightweight-charts (TradingView) og Recharts.
 
 ## Idéen bak arkitekturen
 
-Tre prinsipper styrer alt:
+Prosjektet er en drift-minimal side som skal overleve at styret og
+forvaltningsgruppen skiftes ut hvert år. Det har formet tre valg som resten av
+koden henger på.
 
-1. **Ingen egen database og ingen innlogging.** Alt innhold er enten offentlig
-   data fra Nordnet eller filer i repoet (medlemmer, rapporter). Det finnes
-   ingenting å hacke, ingenting å migrere og ingenting som kan gå ned utenom
-   selve appen. Endringer i innhold er git-commits med full historikk.
-2. **Serveren er eneste vei til Nordnet.** Nordnets API-er krever spesielle
-   headere og skal ikke kalles fra nettleseren. API-rutene i Next henter,
-   normaliserer og cacher; klienten ser bare våre egne typer. Bytter Nordnet
-   API, endres ett bibliotek (`src/lib/nordnet.ts`), ikke komponentene.
-3. **Ærlig data eller ingen data.** Porteføljevekter, honorar og
-   referanseindeks leses fra forvaltningsgruppens egne kvartalsrapporter i
-   `public/reports`. Seksjoner uten data skjules i stedet for å vise
-   plassholdere.
+### 1. Ingen egen database og ingen innlogging
+
+Alt innhold er enten offentlig data fra Nordnet eller filer i repoet
+(medlemmer, rapporter, søknader). Det er ikke fordi en database hadde vært
+vanskelig, men fordi en database er noe som må driftes, sikkerhetsoppdateres,
+migreres og backes opp av folk som byttes ut årlig. En fil i git har full
+historikk gratis, kan reviewes i en pull request, og kan ikke gå ned uten at
+hele appen gjør det.
+
+Avveiningen: skriveoperasjoner (nye medlemmer, nye rapporter) blir git-commits
+i stedet for et admin-panel. Det er tregere for redaktøren, men det fjerner et
+helt lag med autentisering, roller og angrepsflate. For en side som endres noen
+ganger i semesteret er det en god byttehandel.
+
+### 2. Serveren er eneste vei til Nordnet
+
+Nordnets API-er krever spesielle headere (`client-id`, `Referer`) og tåler ikke
+å bli kalt fra nettleseren. API-rutene i Next henter, normaliserer og cacher;
+klienten ser bare våre egne typer i `src/lib/nordnet-types.ts`, aldri Nordnets
+rå respons.
+
+Poenget er isolasjon: bytter Nordnet API-form, endres ett bibliotek
+(`src/lib/nordnet.ts`) og komponentene merker ingenting. Klienten er koblet mot
+et stabilt indre grensesnitt, ikke mot en tredjepart vi ikke styrer.
+
+### 3. Ærlig data eller ingen data
+
+Seksjoner uten data skjules i stedet for å vise plassholdere eller eksempeltall.
+Et tomt felt er et gyldig utfall; en oppdiktet verdi er det ikke. Dette er en
+bevisst regel fordi siden viser et ekte fond med ekte penger, og en pen men
+feil graf er verre enn ingen graf.
 
 ```mermaid
 flowchart LR
@@ -50,9 +75,18 @@ flowchart LR
     K --> R[Resend, e-post til fondet@tihlde.org]
 ```
 
-To cachelag med samme levetid (30 min): ISR på serveren gjør at Nordnet
-maksimalt treffes to ganger i timen uansett trafikk, React Query gjør at
-klienten aldri spør samme side to ganger i samme økt.
+### Hvorfor to cachelag med samme levetid
+
+Både serveren (ISR) og klienten (React Query) cacher i 30 minutter, og det er
+med vilje. De løser to ulike problemer:
+
+- ISR på serveren gjør at Nordnet maksimalt treffes to ganger i timen uansett
+  hvor mange som er inne. Det beskytter tredjeparten mot vår trafikk.
+- React Query gjør at klienten ikke spør samme side to ganger i samme økt.
+  Det beskytter brukeren mot unødige nettverksrunder når de klikker rundt.
+
+Samme tall (30 min) er valgt slik at de to lagene ikke drar i hver sin retning:
+klienten ber aldri om ferskere data enn serveren gidder å hente.
 
 ## Datakilder
 
@@ -66,24 +100,29 @@ Alt hentes uten innlogging. Integrasjonen ligger i `src/lib/nordnet.ts`.
 | Kurshistorikk (fond og indekser) | `api.prod.nntech.io/market-data/v3/price-time-series/period/{PERIOD}/identifier/{uuid}` | Trenger header `Referer: https://www.nordnet.no/`. Fond gir prosent direkte (`?fundType=FUND_NOK`), indekser gir absolutte verdier som omregnes |
 | Indeks-oppslag (OSEBX m.fl.) | `www.nordnet.no/api/2/main_search?query=...` | Finner `market_data_order_book_id` ved kjøretid |
 
-**Begrensninger som former designet:**
+### Begrensninger som former designet
 
 - **Hvilke fond som eies utledes fra handelshistorikken:** et fond regnes som
-  eid når siste handel i fondet er et kjøp. Nordnets API oppgir ikke porteføljen
-  direkte.
+  eid når siste handel i fondet er et kjøp (`getHoldings` i `nordnet.ts`).
+  Nordnets API oppgir ikke porteføljen direkte, så vi bygger den fra
+  aktivitetsfeeden. Feeden hentes i inntil `FEED_MAX_PAGES` sider; øk den hvis
+  et eid fond mangler fordi siste kjøp ligger langt tilbake.
 - **Vekter, honorar og referanseindeks kommer fra kvartalsrapportene.**
-  `src/lib/fordeling.ts` leser nyeste PDF i `public/reports` og matcher hvert
-  tall til fondene Nordnet oppgir som eid. Fond kjøpt etter siste rapport står
-  uten disse tallene til neste rapport kommer.
-- **«TIHLDE-Fondet»-linjen i grafen er et likevektet snitt** av beholdningene,
-  merket som det i UI-et.
-- Ikke vis plassholder- eller eksempeldata. Tomme seksjoner skjules.
+  `src/lib/fordeling.ts` leser nyeste PDF i `public/reports`, parser hvert fonds
+  «Porteføljevekt», «Forvaltningshonorar» og «Referanseindeks», og matcher tallene
+  til fondene Nordnet oppgir som eid. En rapport godtas bare hvis vektene summerer
+  seg til nær 100 %, slik at halvferdige utkast ikke slår gjennom. Fond kjøpt
+  etter siste rapport står uten disse tallene til neste rapport kommer.
+- **«TIHLDE-Fondet»-linjen i grafen er et likevektet snitt** av beholdningene
+  (`equalWeightComposite` i `src/lib/series.ts`), merket som det i UI-et. Den
+  bruker ikke rapportvektene, fordi vektene bare finnes kvartalsvis mens grafen
+  er daglig, og en interpolert vektkurve hadde vært en gjetning vi ikke vil vise.
 
 ## Sider
 
 | Rute | Innhold |
 |------|---------|
-| `/` | Profilkort, utviklingsgraf med indeks-sammenligning, avkastning per fond, sammensetning, handler med paginering |
+| `/` | Profilkort, nøkkeltall, utviklingsgraf med indeks-sammenligning, avkastning per fond og periode, sammensetning, beholdninger og handler |
 | `/about` | Om fondet, vedtekter, årsrapporter |
 | `/apply` + `/apply/skjema` | Søknad om støtte, sendes som e-post via Resend |
 | `/group` + `/group/tidligere` | Forvaltningsgruppen, nåværende og tidligere |
@@ -91,10 +130,10 @@ Alt hentes uten innlogging. Integrasjonen ligger i `src/lib/nordnet.ts`.
 
 ## Hosting og deploy
 
-Appen bygges som et Docker-image og publiseres til GitHub Container
-Registry av GitHub Actions. Push til `dev` gir tag `:dev`, push til
-`main` gir `:latest`. CI (lint, typesjekk, tester, build) kjører på
-alle pusher og pull requests.
+Appen bygges som et Docker-image (`output: "standalone"`) og publiseres til
+GitHub Container Registry av GitHub Actions. Push til `dev` gir tag `:dev`, push
+til `main` gir `:latest`. CI (lint, typesjekk, tester, build) kjører på alle
+pusher og pull requests.
 
 ```mermaid
 flowchart LR
@@ -105,23 +144,27 @@ flowchart LR
     S -->|ISR, 30 min| NN[Nordnet API-er]
 ```
 
+Standalone-bygg er valgt fordi det gir et lite image uten `node_modules`, som
+starter raskt og ikke trenger en kjørende Node-verktøykjede på serveren.
+Deploy-mekanismen er bevisst enkel: `--pull=always` i systemd-enheten betyr at
+en restart av tjenesten er hele oppdateringen, det finnes ingen egen
+deploy-pipeline å vedlikeholde.
+
 Dev-miljøet kjører på en hjemmeserver bak Cloudflare Tunnel på
 fondet.tritacle.no. Serveren kjører `systemd/fondet.service` som en
-brukertjeneste: den starter containeren med `--pull=always`, så en
-restart av tjenesten henter siste `:dev`-image. `RESEND_API_KEY`
-ligger i `.env` på serveren, aldri i imaget eller i repoet.
+brukertjeneste. `RESEND_API_KEY` ligger i `.env` på serveren, aldri i imaget
+eller i repoet.
 
-Prod kan settes opp likt med `:latest`-taggen, eller på Vercel
-(importer repoet, sett `RESEND_API_KEY`, ferdig) om TIHLDE heller
-vil slippe serverdrift.
+Prod kan settes opp likt med `:latest`-taggen, eller på Vercel (importer repoet,
+sett `RESEND_API_KEY`, ferdig) om TIHLDE heller vil slippe serverdrift.
 
 ## Vedlikehold av medlemmer
 
-Alt styres med filer, ingen admin-innlogging:
+Alt styres med filer, ingen admin-innlogging (se prinsipp 1 over):
 
 ```mermaid
 flowchart TD
-    A[Nytt medlem] --> B[Legg til oppføring i src/data/members.json]
+    A[Nytt medlem] --> B[Legg til oppføring i src/data/members.ts]
     B --> C[Legg bilde i public/members/ navngitt som id, f.eks. sigurd-evensen.jpg]
     C --> D[Commit + push, CI bygger og deployer]
     E[Medlem slutter] --> F[Flytt oppføringen til previousMembers og sett endYear]
@@ -164,13 +207,22 @@ npm install
 npm run dev      # http://localhost:3000
 npm run build    # produksjonsbygg
 npm run lint
+npm test         # vitest
 ```
 
-## Design
+## Design og styling
 
-- Tema styres av CSS-variabler i `globals.css` og eksponeres via
-  `tailwind.config.ts` (`bg-cardBackground`, `text-foreground-primary` osv.).
-  Bruk alltid tokens, aldri hardkodede farger som `text-white`.
-- Utviklingsgrafen bruker TradingViews `lightweight-charts`, søylediagram og
+- Tema styres av CSS-variabler i `src/styles/globals.css`. De eksponeres som
+  Tailwind-farger i `@theme`-blokken (`bg-cardBackground`,
+  `text-foreground-primary` osv.). Bruk alltid disse tokenene, aldri hardkodede
+  farger som `text-white`, slik at lyst og mørkt tema følger med automatisk.
+- **Tailwind v4-felle:** en fargeutility lages bare når token-navnet i `@theme`
+  matcher klassen. Komponentene bruker camelCase-navn (`bg-cardBackground`), så
+  `@theme` må definere både kebab-case (`--color-card-background`) og
+  camelCase-aliaset (`--color-cardBackground`). Fjerner du aliaset, produserer
+  klassen ingen CSS og elementet blir bakgrunnsløst uten noen feilmelding.
+- Utviklingsgrafen bruker TradingViews `lightweight-charts`; søylediagram og
   donut bruker Recharts. Grønt for positiv avkastning, rødt for negativ.
 - Kjøp/salg og prosenter vises som farget tekst, ikke fargede bokser.
+- `⌘K` / `Ctrl+K` åpner hurtigsøket (`src/components/CommandPalette.tsx`) for å
+  hoppe mellom sider og bytte tema.

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,7 +2,18 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Search, ArrowRight, Home, FileText, Users, Send, Sun, Moon, Monitor } from "lucide-react";
+import {
+  Search,
+  ArrowRight,
+  Home,
+  FileText,
+  Users,
+  Send,
+  Sun,
+  Moon,
+  Monitor,
+  CornerDownLeft,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTheme } from "@/components/providers/ThemeProvider";
 
@@ -11,9 +22,58 @@ type Command = {
   label: string;
   hint: string;
   keywords: string;
+  group: string;
   icon: LucideIcon;
   run: () => void;
 };
+
+// Order the groups appear in the list. Results stay grouped so navigation and
+// theme actions never get shuffled together.
+const GROUP_ORDER = ["Sider", "Tema"];
+
+// Subsequence fuzzy match: every query char must appear in order. Consecutive
+// hits and hits at the start of a word score higher, so "omf" ranks "Om
+// fondet" above a scattered match. Returns the hit positions for highlighting,
+// or null when the query does not fit.
+function fuzzy(query: string, text: string): { score: number; hits: number[] } | null {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  const hits: number[] = [];
+  let qi = 0;
+  let streak = 0;
+  let score = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      hits.push(ti);
+      streak += 1;
+      score += streak * 2;
+      if (ti === 0 || t[ti - 1] === " ") score += 5;
+      qi += 1;
+    } else {
+      streak = 0;
+    }
+  }
+  if (qi < q.length) return null;
+  return { score: score - t.length * 0.1, hits };
+}
+
+function Highlight({ text, hits }: { text: string; hits: number[] }) {
+  if (hits.length === 0) return <>{text}</>;
+  const set = new Set(hits);
+  return (
+    <>
+      {text.split("").map((ch, i) =>
+        set.has(i) ? (
+          <span key={i} className="text-accent font-semibold">
+            {ch}
+          </span>
+        ) : (
+          <span key={i}>{ch}</span>
+        ),
+      )}
+    </>
+  );
+}
 
 export default function CommandPalette() {
   const router = useRouter();
@@ -34,26 +94,51 @@ export default function CommandPalette() {
       setOpen(false);
       router.push(path);
     };
+    const theme = (t: "light" | "dark" | "system") => () => {
+      setTheme(t);
+      setOpen(false);
+    };
     return [
-      { id: "home", label: "Forsiden", hint: "Oversikt og live tall", keywords: "hjem start portefolje dashboard", icon: Home, run: go("/") },
-      { id: "about", label: "Om fondet", hint: "Hva Fondet er", keywords: "about historie", icon: FileText, run: go("/about") },
-      { id: "reports", label: "Rapporter", hint: "Kvartals- og arsrapporter", keywords: "reports kvartal arsrapport dokumenter soknader", icon: FileText, run: go("/reports") },
-      { id: "group", label: "Forvaltningsgruppen", hint: "Medlemmer", keywords: "group gruppe medlemmer team", icon: Users, run: go("/group") },
-      { id: "group-prev", label: "Tidligere medlemmer", hint: "Arkiv", keywords: "tidligere alumni historikk", icon: Users, run: go("/group/tidligere") },
-      { id: "apply", label: "Søk om støtte", hint: "Slik søker du", keywords: "apply soknad stotte penger", icon: Send, run: go("/apply") },
-      { id: "apply-form", label: "Søknadsskjema", hint: "Fyll ut og send", keywords: "skjema form soknad", icon: Send, run: go("/apply/skjema") },
-      { id: "theme-light", label: "Lyst tema", hint: "Bytt utseende", keywords: "theme lys light dag", icon: Sun, run: () => { setTheme("light"); setOpen(false); } },
-      { id: "theme-dark", label: "Mørkt tema", hint: "Bytt utseende", keywords: "theme mork dark natt", icon: Moon, run: () => { setTheme("dark"); setOpen(false); } },
-      { id: "theme-system", label: "Systemtema", hint: "Følg operativsystemet", keywords: "theme system auto", icon: Monitor, run: () => { setTheme("system"); setOpen(false); } },
+      { id: "home", label: "Forsiden", hint: "Oversikt og live tall", keywords: "hjem start portefolje dashboard", group: "Sider", icon: Home, run: go("/") },
+      { id: "about", label: "Om fondet", hint: "Hva Fondet er", keywords: "about historie vedtekter", group: "Sider", icon: FileText, run: go("/about") },
+      { id: "reports", label: "Rapporter", hint: "Kvartals- og årsrapporter", keywords: "reports kvartal arsrapport dokumenter", group: "Sider", icon: FileText, run: go("/reports") },
+      { id: "group", label: "Forvaltningsgruppen", hint: "Medlemmer", keywords: "group gruppe medlemmer team", group: "Sider", icon: Users, run: go("/group") },
+      { id: "group-prev", label: "Tidligere medlemmer", hint: "Arkiv", keywords: "tidligere alumni historikk", group: "Sider", icon: Users, run: go("/group/tidligere") },
+      { id: "apply", label: "Søk om støtte", hint: "Slik søker du", keywords: "apply soknad stotte penger", group: "Sider", icon: Send, run: go("/apply") },
+      { id: "apply-form", label: "Søknadsskjema", hint: "Fyll ut og send", keywords: "skjema form soknad", group: "Sider", icon: Send, run: go("/apply/skjema") },
+      { id: "theme-light", label: "Lyst tema", hint: "Bytt utseende", keywords: "theme lys light dag", group: "Tema", icon: Sun, run: theme("light") },
+      { id: "theme-dark", label: "Mørkt tema", hint: "Bytt utseende", keywords: "theme mork dark natt", group: "Tema", icon: Moon, run: theme("dark") },
+      { id: "theme-system", label: "Systemtema", hint: "Følg operativsystemet", keywords: "theme system auto", group: "Tema", icon: Monitor, run: theme("system") },
     ];
   }, [router, setTheme]);
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return commands;
-    return commands.filter(
-      (c) => c.label.toLowerCase().includes(q) || c.keywords.includes(q),
-    );
+  // Rank by fuzzy score across label, hint and keywords. Label hits drive the
+  // highlight; a match found only in keywords still lists the item, just
+  // without highlighting. With no query the list keeps its authored order.
+  const results = useMemo(() => {
+    const q = query.trim();
+    const scored = commands
+      .map((c) => {
+        if (!q) return { c, score: 0, hits: [] as number[] };
+        const inLabel = fuzzy(q, c.label);
+        const inHint = fuzzy(q, c.hint);
+        const inKw = fuzzy(q, c.keywords);
+        const best = [inLabel, inHint, inKw]
+          .filter((m): m is { score: number; hits: number[] } => m !== null)
+          .sort((a, b) => b.score - a.score)[0];
+        if (!best) return null;
+        return {
+          c,
+          score: best.score + (inLabel ? 3 : 0),
+          hits: inLabel?.hits ?? [],
+        };
+      })
+      .filter((r): r is { c: Command; score: number; hits: number[] } => r !== null);
+
+    if (q) scored.sort((a, b) => b.score - a.score);
+    // Flatten into the fixed group order so the visible order matches the
+    // index the arrow keys walk through.
+    return GROUP_ORDER.flatMap((g) => scored.filter((r) => r.c.group === g));
   }, [commands, query]);
 
   // Global shortcut: Cmd/Ctrl+K toggles the palette.
@@ -113,22 +198,24 @@ export default function CommandPalette() {
   const onInputKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setActive((i) => Math.min(i + 1, filtered.length - 1));
+      setActive((i) => Math.min(i + 1, results.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setActive((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      filtered[active]?.run();
+      results[active]?.c.run();
     } else if (e.key === "Escape") {
       e.preventDefault();
       setOpen(false);
     }
   };
 
+  let flatIndex = -1;
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 px-4 pt-[15vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 px-4 pt-[15vh] backdrop-blur-sm"
       onClick={() => setOpen(false)}
     >
       <div
@@ -150,7 +237,7 @@ export default function CommandPalette() {
             aria-expanded="true"
             aria-controls="cmd-listbox"
             aria-activedescendant={
-              filtered[active] ? `cmd-opt-${active}` : undefined
+              results[active] ? `cmd-opt-${active}` : undefined
             }
             aria-autocomplete="list"
             placeholder="Søk sider og handlinger…"
@@ -159,45 +246,78 @@ export default function CommandPalette() {
         </div>
 
         <ul id="cmd-listbox" role="listbox" className="max-h-80 overflow-y-auto py-2">
-          {filtered.length === 0 && (
-            <li className="px-4 py-6 text-center text-sm text-foreground-secondary">
-              Ingen treff
+          {results.length === 0 && (
+            <li className="px-4 py-8 text-center text-sm text-foreground-secondary">
+              Ingen treff for «{query.trim()}»
             </li>
           )}
-          {filtered.map((c, i) => {
-            const Icon = c.icon;
-            const selected = i === active;
+          {GROUP_ORDER.map((group) => {
+            const inGroup = results.filter((r) => r.c.group === group);
+            if (inGroup.length === 0) return null;
             return (
-              <li
-                key={c.id}
-                id={`cmd-opt-${i}`}
-                role="option"
-                aria-selected={selected}
-                onMouseEnter={() => setActive(i)}
-                onClick={c.run}
-                className={`mx-2 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 ${
-                  selected ? "bg-cardBorder/50" : ""
-                }`}
-              >
-                <Icon className="h-4 w-4 text-accent shrink-0" aria-hidden />
-                <span className="flex-1 min-w-0">
-                  <span className="block truncate text-sm text-foreground-primary">
-                    {c.label}
-                  </span>
-                  <span className="block truncate text-xs text-foreground-secondary">
-                    {c.hint}
-                  </span>
-                </span>
-                {selected && (
-                  <ArrowRight
-                    className="h-4 w-4 text-foreground-secondary shrink-0"
-                    aria-hidden
-                  />
-                )}
+              <li key={group} role="presentation">
+                <div className="px-4 pt-2 pb-1 text-xs font-semibold uppercase tracking-wide text-foreground-secondary">
+                  {group}
+                </div>
+                <ul role="presentation">
+                  {inGroup.map((r) => {
+                    flatIndex += 1;
+                    const i = flatIndex;
+                    const Icon = r.c.icon;
+                    const selected = i === active;
+                    return (
+                      <li
+                        key={r.c.id}
+                        id={`cmd-opt-${i}`}
+                        role="option"
+                        aria-selected={selected}
+                        onMouseEnter={() => setActive(i)}
+                        onClick={r.c.run}
+                        className={`mx-2 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 ${
+                          selected ? "bg-cardBorder/50" : ""
+                        }`}
+                      >
+                        <Icon className="h-4 w-4 text-accent shrink-0" aria-hidden />
+                        <span className="flex-1 min-w-0">
+                          <span className="block truncate text-sm text-foreground-primary">
+                            <Highlight text={r.c.label} hits={r.hits} />
+                          </span>
+                          <span className="block truncate text-xs text-foreground-secondary">
+                            {r.c.hint}
+                          </span>
+                        </span>
+                        {selected && (
+                          <ArrowRight
+                            className="h-4 w-4 text-foreground-secondary shrink-0"
+                            aria-hidden
+                          />
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
               </li>
             );
           })}
         </ul>
+
+        <div className="flex items-center gap-4 border-t border-cardBorder px-4 py-2 text-xs text-foreground-secondary">
+          <span className="inline-flex items-center gap-1">
+            <kbd className="rounded border border-cardBorder px-1">↑</kbd>
+            <kbd className="rounded border border-cardBorder px-1">↓</kbd>
+            naviger
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <kbd className="rounded border border-cardBorder px-1">
+              <CornerDownLeft className="h-3 w-3" aria-hidden />
+            </kbd>
+            velg
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <kbd className="rounded border border-cardBorder px-1">esc</kbd>
+            lukk
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/lib/nordnet.ts
+++ b/src/lib/nordnet.ts
@@ -87,7 +87,7 @@ export interface Trade {
 }
 
 const FEED_PAGE_SIZE = 50;
-const FEED_MAX_PAGES = 6;
+const FEED_MAX_PAGES = 30;
 
 export async function getTrades(): Promise<Trade[]> {
   const profile = await getProfile();


### PR DESCRIPTION
Brings the dashboard-independent work over from the admin-area branch so it ships without waiting for that feature:

- README rewritten for developers: the reasoning behind no-database, server-only Nordnet access, the honest-data rule, cache layering, data source limits and a documented Tailwind v4 camelCase-token gotcha
- CHANGELOG.md added in the TIHLDE version-per-date format, built from real git history, including entries for today's skeleton loading and dependency bumps
- Command palette search rewritten: fuzzy subsequence matching, ranked results, match highlighting, grouped sections behind an opaque panel
- Activity feed read 30 pages deep instead of 6 so funds bought far back never silently drop out of the derived portfolio; the loop still stops early at endOfFeed

Verified: tsc clean, eslint clean, 41 tests pass, production build succeeds.