### PR TITLE
feat: admin area for forvaltere

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,24 @@
+# Resend API key for the application form and magic-link login emails.
+# Without it the form responds with a clear error and no email is sent.
+RESEND_API_KEY=
+
+# Public origin of the site, e.g. https://fondet.tihlde.org. Used as the base
+# for magic-link login URLs. Required in production: deriving it from the Host
+# header would let a forged Host steer the mailed login link (and its token)
+# to an attacker's domain. Unset falls back to the request origin in dev only.
+APP_BASE_URL=
+
+# Comma-separated email addresses allowed to log in to the admin area.
+# Fallback only: if admins.json exists in DATA_DIR it takes precedence.
+ADMIN_EMAILS=
+
+# Secret used to sign magic-link login tokens. Required for admin login.
+AUTH_SECRET=
+
+# Optional. Directory for runtime JSON data (admins.json, soknader). In
+# production a mounted volume. Unset falls back to ./data in the repo.
+DATA_DIR=
+
 # Optional. Absolute path to a directory of member portraits and group photos
 # served at runtime via /api/members/<file>. In production this is a mounted
 # volume so images live on the server, not in the repo or the built image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# CHANGELOG
+
+## Tegnforklaring
+
+### ✨ - Ny funksjonalitet
+
+### ⚡ - Forbedret funksjonalitet
+
+### 🦟 - Fikset en bug
+
+### 🎨 - Designendringer
+
+---
+
+## Neste versjon
+
+## Versjon 2026.07.17
+- ⚡ **Hurtigsøk**. Søket (⌘K / Ctrl+K) bruker nå fuzzy-matching med rangering og utheving av treff, grupperer sider og temavalg, og har et ugjennomsiktig panel som ikke lenger lekker sideinnholdet bak seg.
+- ✨ **Kommandopalett**. Åpne søk med ⌘K / Ctrl+K for å hoppe mellom sider og bytte tema.
+- ✨ **Beholdningstabell**. Radene kan sorteres på kolonne og utvides for detaljer om hvert fond.
+- ✨ **Avkastningsmatrise**. Avkastning per fond og periode vises i egen tabell, farget etter fortegn i stedet for fargede bokser.
+- ✨ **Porteføljebredde**. Ny stolpe i avkastningskortet viser hvor mange fond som er i pluss.
+- ✨ **Fondsticker**. Rullende bånd øverst viser hvert fonds YTD-avkastning, pauser på hover.
+- ✨ **Ferskhetsindikator**. Under toppseksjonen vises når dataene sist ble hentet fra Nordnet.
+- ✨ **Treemap**. Sammensetningen kan ses som treemap farget etter årets avkastning.
+- ✨ **Til toppen**. Knapp som ruller dashbordet tilbake til toppen.
+- 🎨 **Nøkkeltall**. Tallene teller opp ved innlasting, seksjoner tones inn ved scroll, og gevinst/tap markeres med piler.
+- 🎨 **Kort**. Dashbordkortene løftes et hakk ved hover.
+- 🦟 **Temafarger**. Kort-, knapp- og input-bakgrunner ble borte fordi camelCase-fargeklassene ikke lagde CSS i Tailwind v4. Alias er lagt til så bakgrunnene rendrer igjen.
+- 🦟 **Mobilmeny**. Menyen er nå ugjennomsiktig når den er åpen, så innholdet bak ikke skinner gjennom.
+- 🎨 **Bidra-lenke**. Footeren lenker nå til kildekoden på GitHub.
+- ⚡ **Dokumentasjon**. README er skrevet om for utviklere: arkitekturvalg med begrunnelse, datakilder, begrensninger og en Tailwind v4-felle.
+
+## Versjon 2026.07.16
+- ✨ **Sammenligningsgraf**. Utviklingsgrafen kan sammenlignes med verdensindekser, og har indikatorer og tegneverktøy.
+- 🦟 **Bilder på Vercel**. Medlems- og gruppebilder rendrer nå også i serverless-miljø.
+- ⚡ **Medlemsliste**. Oppdatert forvaltningsgruppe og nytt navn på søknadsseksjonen.
+
+## Versjon 2026.07.15
+- ✨ **Kvartalsrapporter 2025**. Publisert på /reports.
+- ✨ **Grafverktøy**. La til analyseverktøy, indekser og «tøm alt» i grafen.
+- ✨ **Tidligere medlemmer**. Årsmerket gruppekarusell og paginert liste.
+- ✨ **Volumbilder**. Medlemsbilder serveres fra et montert volum i produksjon, ikke fra repoet.
+- 🦟 **Portretter**. Rettet feilmerkede portretter fra fotoseansene.
+- 🦟 **Graf**. Herdet forhåndsvisningen mot crosshair-rekursjon; beholder fullskjerm når Esc avbryter et tegneverktøy.
+
+## Versjon 2026.07.14
+- ✨ **Live portefølje**. Viser fondets beholdning direkte fra den offentlige Nordnet Shareville-profilen.
+- ✨ **Søknadsskjema**. Egen side med validering i sanntid, sendt som e-post via Resend.
+- ✨ **Rapportside**. /reports med årsrapport som PDF.
+- ✨ **Medlemskort**. Portretter, studie og periode på hvert kort, med roterende gruppebilde.
+- ✨ **Tidligere søknader**. Paginert liste med én rad per søknad og vedtak.
+- 🎨 **Tilgjengelighet**. Kontrast, berøringsmål, fokusmarkering og sidetitler ryddet opp.
+- 🦟 **Content-API**. Fjernet uautentisert PUT og PUT-basert innholdsredigering.
+- ⚡ **Om fondet**. Omskrevet i enklere språk.
+- ⚡ **Arkitektur**. Fjernet adminpanel, innlogging og Firebase-datalag til fordel for offentlig data og filer i repoet.

--- a/README.md
+++ b/README.md
@@ -4,25 +4,50 @@ Nettside for TIHLDE sitt investeringsfond. Viser porteføljen live fra fondets
 offentlige Nordnet-profil, medlemmene i forvaltningsgruppen, rapporter og
 søknadsskjema for støtte.
 
-Stack: Next.js (App Router), TypeScript, Tailwind CSS, React Query,
+Dette dokumentet er skrevet for utviklere som skal videreutvikle eller drifte
+siden. Det forklarer ikke bare hva som er bygget, men hvorfor det er bygget
+slik, og hvilke avveininger som ligger bak.
+
+Stack: Next.js 14 (App Router), TypeScript, Tailwind CSS v4, React Query,
 lightweight-charts (TradingView) og Recharts.
 
 ## Idéen bak arkitekturen
 
-Tre prinsipper styrer alt:
+Prosjektet er en drift-minimal side som skal overleve at styret og
+forvaltningsgruppen skiftes ut hvert år. Det har formet tre valg som resten av
+koden henger på.
 
-1. **Ingen egen database og ingen innlogging.** Alt innhold er enten offentlig
-   data fra Nordnet eller filer i repoet (medlemmer, rapporter). Det finnes
-   ingenting å hacke, ingenting å migrere og ingenting som kan gå ned utenom
-   selve appen. Endringer i innhold er git-commits med full historikk.
-2. **Serveren er eneste vei til Nordnet.** Nordnets API-er krever spesielle
-   headere og skal ikke kalles fra nettleseren. API-rutene i Next henter,
-   normaliserer og cacher; klienten ser bare våre egne typer. Bytter Nordnet
-   API, endres ett bibliotek (`src/lib/nordnet.ts`), ikke komponentene.
-3. **Ærlig data eller ingen data.** Porteføljevekter, honorar og
-   referanseindeks leses fra forvaltningsgruppens egne kvartalsrapporter i
-   `public/reports`. Seksjoner uten data skjules i stedet for å vise
-   plassholdere.
+### 1. Ingen egen database og ingen innlogging
+
+Alt innhold er enten offentlig data fra Nordnet eller filer i repoet
+(medlemmer, rapporter, søknader). Det er ikke fordi en database hadde vært
+vanskelig, men fordi en database er noe som må driftes, sikkerhetsoppdateres,
+migreres og backes opp av folk som byttes ut årlig. En fil i git har full
+historikk gratis, kan reviewes i en pull request, og kan ikke gå ned uten at
+hele appen gjør det.
+
+Avveiningen: skriveoperasjoner (nye medlemmer, nye rapporter) blir git-commits
+i stedet for et admin-panel. Det er tregere for redaktøren, men det fjerner et
+helt lag med autentisering, roller og angrepsflate. For en side som endres noen
+ganger i semesteret er det en god byttehandel.
+
+### 2. Serveren er eneste vei til Nordnet
+
+Nordnets API-er krever spesielle headere (`client-id`, `Referer`) og tåler ikke
+å bli kalt fra nettleseren. API-rutene i Next henter, normaliserer og cacher;
+klienten ser bare våre egne typer i `src/lib/nordnet-types.ts`, aldri Nordnets
+rå respons.
+
+Poenget er isolasjon: bytter Nordnet API-form, endres ett bibliotek
+(`src/lib/nordnet.ts`) og komponentene merker ingenting. Klienten er koblet mot
+et stabilt indre grensesnitt, ikke mot en tredjepart vi ikke styrer.
+
+### 3. Ærlig data eller ingen data
+
+Seksjoner uten data skjules i stedet for å vise plassholdere eller eksempeltall.
+Et tomt felt er et gyldig utfall; en oppdiktet verdi er det ikke. Dette er en
+bevisst regel fordi siden viser et ekte fond med ekte penger, og en pen men
+feil graf er verre enn ingen graf.
 
 ```mermaid
 flowchart LR
@@ -50,9 +75,18 @@ flowchart LR
     K --> R[Resend, e-post til fondet@tihlde.org]
 ```
 
-To cachelag med samme levetid (30 min): ISR på serveren gjør at Nordnet
-maksimalt treffes to ganger i timen uansett trafikk, React Query gjør at
-klienten aldri spør samme side to ganger i samme økt.
+### Hvorfor to cachelag med samme levetid
+
+Både serveren (ISR) og klienten (React Query) cacher i 30 minutter, og det er
+med vilje. De løser to ulike problemer:
+
+- ISR på serveren gjør at Nordnet maksimalt treffes to ganger i timen uansett
+  hvor mange som er inne. Det beskytter tredjeparten mot vår trafikk.
+- React Query gjør at klienten ikke spør samme side to ganger i samme økt.
+  Det beskytter brukeren mot unødige nettverksrunder når de klikker rundt.
+
+Samme tall (30 min) er valgt slik at de to lagene ikke drar i hver sin retning:
+klienten ber aldri om ferskere data enn serveren gidder å hente.
 
 ## Datakilder
 
@@ -66,24 +100,29 @@ Alt hentes uten innlogging. Integrasjonen ligger i `src/lib/nordnet.ts`.
 | Kurshistorikk (fond og indekser) | `api.prod.nntech.io/market-data/v3/price-time-series/period/{PERIOD}/identifier/{uuid}` | Trenger header `Referer: https://www.nordnet.no/`. Fond gir prosent direkte (`?fundType=FUND_NOK`), indekser gir absolutte verdier som omregnes |
 | Indeks-oppslag (OSEBX m.fl.) | `www.nordnet.no/api/2/main_search?query=...` | Finner `market_data_order_book_id` ved kjøretid |
 
-**Begrensninger som former designet:**
+### Begrensninger som former designet
 
 - **Hvilke fond som eies utledes fra handelshistorikken:** et fond regnes som
-  eid når siste handel i fondet er et kjøp. Nordnets API oppgir ikke porteføljen
-  direkte.
+  eid når siste handel i fondet er et kjøp (`getHoldings` i `nordnet.ts`).
+  Nordnets API oppgir ikke porteføljen direkte, så vi bygger den fra
+  aktivitetsfeeden. Feeden hentes i inntil `FEED_MAX_PAGES` sider; øk den hvis
+  et eid fond mangler fordi siste kjøp ligger langt tilbake.
 - **Vekter, honorar og referanseindeks kommer fra kvartalsrapportene.**
-  `src/lib/fordeling.ts` leser nyeste PDF i `public/reports` og matcher hvert
-  tall til fondene Nordnet oppgir som eid. Fond kjøpt etter siste rapport står
-  uten disse tallene til neste rapport kommer.
-- **«TIHLDE-Fondet»-linjen i grafen er et likevektet snitt** av beholdningene,
-  merket som det i UI-et.
-- Ikke vis plassholder- eller eksempeldata. Tomme seksjoner skjules.
+  `src/lib/fordeling.ts` leser nyeste PDF i `public/reports`, parser hvert fonds
+  «Porteføljevekt», «Forvaltningshonorar» og «Referanseindeks», og matcher tallene
+  til fondene Nordnet oppgir som eid. En rapport godtas bare hvis vektene summerer
+  seg til nær 100 %, slik at halvferdige utkast ikke slår gjennom. Fond kjøpt
+  etter siste rapport står uten disse tallene til neste rapport kommer.
+- **«TIHLDE-Fondet»-linjen i grafen er et likevektet snitt** av beholdningene
+  (`equalWeightComposite` i `src/lib/series.ts`), merket som det i UI-et. Den
+  bruker ikke rapportvektene, fordi vektene bare finnes kvartalsvis mens grafen
+  er daglig, og en interpolert vektkurve hadde vært en gjetning vi ikke vil vise.
 
 ## Sider
 
 | Rute | Innhold |
 |------|---------|
-| `/` | Profilkort, utviklingsgraf med indeks-sammenligning, avkastning per fond, sammensetning, handler med paginering |
+| `/` | Profilkort, nøkkeltall, utviklingsgraf med indeks-sammenligning, avkastning per fond og periode, sammensetning, beholdninger og handler |
 | `/about` | Om fondet, vedtekter, årsrapporter |
 | `/apply` + `/apply/skjema` | Søknad om støtte, sendes som e-post via Resend |
 | `/group` + `/group/tidligere` | Forvaltningsgruppen, nåværende og tidligere |
@@ -91,10 +130,10 @@ Alt hentes uten innlogging. Integrasjonen ligger i `src/lib/nordnet.ts`.
 
 ## Hosting og deploy
 
-Appen bygges som et Docker-image og publiseres til GitHub Container
-Registry av GitHub Actions. Push til `dev` gir tag `:dev`, push til
-`main` gir `:latest`. CI (lint, typesjekk, tester, build) kjører på
-alle pusher og pull requests.
+Appen bygges som et Docker-image (`output: "standalone"`) og publiseres til
+GitHub Container Registry av GitHub Actions. Push til `dev` gir tag `:dev`, push
+til `main` gir `:latest`. CI (lint, typesjekk, tester, build) kjører på alle
+pusher og pull requests.
 
 ```mermaid
 flowchart LR
@@ -105,23 +144,27 @@ flowchart LR
     S -->|ISR, 30 min| NN[Nordnet API-er]
 ```
 
+Standalone-bygg er valgt fordi det gir et lite image uten `node_modules`, som
+starter raskt og ikke trenger en kjørende Node-verktøykjede på serveren.
+Deploy-mekanismen er bevisst enkel: `--pull=always` i systemd-enheten betyr at
+en restart av tjenesten er hele oppdateringen, det finnes ingen egen
+deploy-pipeline å vedlikeholde.
+
 Dev-miljøet kjører på en hjemmeserver bak Cloudflare Tunnel på
 fondet.tritacle.no. Serveren kjører `systemd/fondet.service` som en
-brukertjeneste: den starter containeren med `--pull=always`, så en
-restart av tjenesten henter siste `:dev`-image. `RESEND_API_KEY`
-ligger i `.env` på serveren, aldri i imaget eller i repoet.
+brukertjeneste. `RESEND_API_KEY` ligger i `.env` på serveren, aldri i imaget
+eller i repoet.
 
-Prod kan settes opp likt med `:latest`-taggen, eller på Vercel
-(importer repoet, sett `RESEND_API_KEY`, ferdig) om TIHLDE heller
-vil slippe serverdrift.
+Prod kan settes opp likt med `:latest`-taggen, eller på Vercel (importer repoet,
+sett `RESEND_API_KEY`, ferdig) om TIHLDE heller vil slippe serverdrift.
 
 ## Vedlikehold av medlemmer
 
-Alt styres med filer, ingen admin-innlogging:
+Alt styres med filer, ingen admin-innlogging (se prinsipp 1 over):
 
 ```mermaid
 flowchart TD
-    A[Nytt medlem] --> B[Legg til oppføring i src/data/members.json]
+    A[Nytt medlem] --> B[Legg til oppføring i src/data/members.ts]
     B --> C[Legg bilde i public/members/ navngitt som id, f.eks. sigurd-evensen.jpg]
     C --> D[Commit + push, CI bygger og deployer]
     E[Medlem slutter] --> F[Flytt oppføringen til previousMembers og sett endYear]
@@ -164,13 +207,22 @@ npm install
 npm run dev      # http://localhost:3000
 npm run build    # produksjonsbygg
 npm run lint
+npm test         # vitest
 ```
 
-## Design
+## Design og styling
 
-- Tema styres av CSS-variabler i `globals.css` og eksponeres via
-  `tailwind.config.ts` (`bg-cardBackground`, `text-foreground-primary` osv.).
-  Bruk alltid tokens, aldri hardkodede farger som `text-white`.
-- Utviklingsgrafen bruker TradingViews `lightweight-charts`, søylediagram og
+- Tema styres av CSS-variabler i `src/styles/globals.css`. De eksponeres som
+  Tailwind-farger i `@theme`-blokken (`bg-cardBackground`,
+  `text-foreground-primary` osv.). Bruk alltid disse tokenene, aldri hardkodede
+  farger som `text-white`, slik at lyst og mørkt tema følger med automatisk.
+- **Tailwind v4-felle:** en fargeutility lages bare når token-navnet i `@theme`
+  matcher klassen. Komponentene bruker camelCase-navn (`bg-cardBackground`), så
+  `@theme` må definere både kebab-case (`--color-card-background`) og
+  camelCase-aliaset (`--color-cardBackground`). Fjerner du aliaset, produserer
+  klassen ingen CSS og elementet blir bakgrunnsløst uten noen feilmelding.
+- Utviklingsgrafen bruker TradingViews `lightweight-charts`; søylediagram og
   donut bruker Recharts. Grønt for positiv avkastning, rødt for negativ.
 - Kjøp/salg og prosenter vises som farget tekst, ikke fargede bokser.
+- `⌘K` / `Ctrl+K` åpner hurtigsøket (`src/components/CommandPalette.tsx`) for å
+  hoppe mellom sider og bytte tema.

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test("anonymous visit to /admin redirects to the login page", async ({
+  page,
+}) => {
+  await page.goto("/admin");
+  await expect(page).toHaveURL(/\/admin\/login/);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Logg inn" }),
+  ).toBeVisible();
+});
+
+test("login form always answers with the generic confirmation", async ({
+  page,
+}) => {
+  await page.goto("/admin/login");
+  await page.getByLabel("E-postadresse").fill("ukjent@tihlde.org");
+  await page.getByRole("button", { name: "Send innloggingslenke" }).click();
+  await expect(
+    page.getByText("Hvis adressen er autorisert, er en innloggingslenke sendt."),
+  ).toBeVisible();
+});

--- a/e2e/site.spec.ts
+++ b/e2e/site.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from "@playwright/test";
 
 const PAGES = [
-  { path: "/", heading: "Fondet" },
+  { path: "/", heading: "TIHLDE sitt fond" },
   { path: "/about", heading: "Om fondet" },
   { path: "/group", heading: "Forvaltningsgruppen" },
   { path: "/group/tidligere", heading: "Tidligere medlemmer" },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,15 @@ const nextConfig = {
       "/api/nordnet": ["./public/reports/**/*"],
       "/api/content": ["./src/data/*.json"],
       "/api/soknader": ["./src/data/*.json"],
+      // Admin routes edit the same JSON files, so the committed fallbacks must
+      // be traced into them as well.
+      "/api/admin/members": ["./src/data/*.json"],
+      "/api/admin/members/[id]": ["./src/data/*.json"],
+      "/api/admin/members/[id]/portrait": ["./src/data/*.json"],
+      "/api/admin/reports": ["./src/data/*.json"],
+      "/api/admin/reports/[index]": ["./src/data/*.json"],
+      "/api/admin/soknader": ["./src/data/*.json"],
+      "/api/admin/soknader/[index]": ["./src/data/*.json"],
     },
   },
   images: {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,32 @@
+import { cookies } from "next/headers";
+import { SESSION_COOKIE } from "@/lib/auth-token";
+import { Button } from "@/components/ui/button";
+
+export const metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Middleware has already verified the token for everything except the login
+  // page; this only decides whether the logout button makes sense to show.
+  const loggedIn = cookies().has(SESSION_COOKIE);
+  return (
+    <div className="w-full max-w-5xl mx-auto px-4 py-8">
+      {loggedIn && (
+        <div className="flex items-center justify-end mb-6">
+          <form action="/api/auth/logout" method="post">
+            <Button type="submit" variant="outline">
+              Logg ut
+            </Button>
+          </form>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,23 @@
+import MembersAdmin from "@/components/admin/MembersAdmin";
+import GroupImagesAdmin from "@/components/admin/GroupImagesAdmin";
+import ReportsAdmin from "@/components/admin/ReportsAdmin";
+import SoknaderAdmin from "@/components/admin/SoknaderAdmin";
+
+export default function AdminPage() {
+  return (
+    <main>
+      <h1 className="text-3xl font-bold text-foreground-primary mb-2">
+        Adminpanel
+      </h1>
+      <p className="text-foreground-secondary mb-10">
+        Endringer lagres med en gang og vises direkte på siden.
+      </p>
+      <div className="space-y-12">
+        <MembersAdmin />
+        <GroupImagesAdmin />
+        <ReportsAdmin />
+        <SoknaderAdmin />
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/admin/group-images/route.ts
+++ b/src/app/api/admin/group-images/route.ts
@@ -1,0 +1,124 @@
+import fs from "fs";
+import path from "path";
+import sharp from "sharp";
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { uploadImageDir } from "@/lib/member-images";
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+// group.jpg / group-2.jpg for the current carousel, group-2024-1.jpg style for
+// the archive on the previous members page. Same convention as
+// resolveGroupImages / resolveArchiveGroupImages.
+const NAME = /^group(-[2-9]|-\d{4}-\d{1,2})?$/;
+const FILE = /^group(-\d+|-\d{4}-\d{1,2})?\.(jpg|jpeg|png|webp)$/;
+
+const REPO_DIR = path.join(process.cwd(), "public", "members");
+
+type GroupImage = { file: string; url: string; source: "volume" | "repo" };
+
+function list(dir: string, source: GroupImage["source"]): GroupImage[] {
+  let files: string[] = [];
+  try {
+    files = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return files
+    .filter((f) => FILE.test(f))
+    .sort()
+    .map((f) => ({
+      file: f,
+      url: source === "repo" ? `/members/${f}` : `/api/members/${f}`,
+      source,
+    }));
+}
+
+export async function GET(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+  const volume = list(uploadImageDir(), "volume");
+  // repo copies shadowed by a volume file with the same name are dropped,
+  // matching how the public pages resolve them
+  const shadowed = new Set(volume.map((i) => i.file));
+  const repo = list(REPO_DIR, "repo").filter((i) => !shadowed.has(i.file));
+  return NextResponse.json({ images: [...volume, ...repo] });
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  const name = String(form?.get("name") ?? "").trim();
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Mangler fil" }, { status: 400 });
+  }
+  if (!NAME.test(name)) {
+    return NextResponse.json(
+      {
+        error:
+          "Ugyldig navn. Bruk group, group-2 ... group-9, eller group-ÅÅÅÅ-N for arkivbilder",
+      },
+      { status: 400 },
+    );
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Bildet er for stort (maks 10 MB)" },
+      { status: 400 },
+    );
+  }
+
+  let processed: Buffer;
+  try {
+    processed = await sharp(Buffer.from(await file.arrayBuffer()))
+      .rotate()
+      .resize(2400, 2400, { fit: "inside", withoutEnlargement: true })
+      .jpeg({ quality: 85 })
+      .toBuffer();
+  } catch {
+    return NextResponse.json(
+      { error: "Filen er ikke et gyldig bilde" },
+      { status: 400 },
+    );
+  }
+
+  const dir = uploadImageDir();
+  fs.mkdirSync(dir, { recursive: true });
+  for (const ext of [".jpeg", ".png", ".webp"]) {
+    fs.rmSync(path.join(dir, name + ext), { force: true });
+  }
+  fs.writeFileSync(path.join(dir, name + ".jpg"), processed);
+  return NextResponse.json({
+    file: `${name}.jpg`,
+    url: `/api/members/${name}.jpg`,
+  });
+}
+
+export async function DELETE(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let file = "";
+  try {
+    const body = await request.json();
+    file = path.basename(String(body?.file ?? ""));
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  if (!FILE.test(file)) {
+    return NextResponse.json({ error: "Ugyldig filnavn" }, { status: 400 });
+  }
+
+  const full = path.join(uploadImageDir(), file);
+  if (fs.existsSync(full)) {
+    fs.rmSync(full);
+    return NextResponse.json({ ok: true });
+  }
+  if (fs.existsSync(path.join(REPO_DIR, file))) {
+    return NextResponse.json(
+      { error: "Bildet ligger i repoet og kan bare fjernes derfra" },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ error: "Fant ikke bildet" }, { status: 404 });
+}

--- a/src/app/api/admin/members/[id]/portrait/route.ts
+++ b/src/app/api/admin/members/[id]/portrait/route.ts
@@ -1,0 +1,92 @@
+import fs from "fs";
+import path from "path";
+import sharp from "sharp";
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson } from "@/lib/data-store";
+import type { MembersFile } from "@/data/members";
+import { IMAGE_EXTENSIONS, uploadImageDir } from "@/lib/member-images";
+
+const MAX_BYTES = 5 * 1024 * 1024;
+
+type Params = { params: { id: string } };
+
+function knownMember(id: string): boolean {
+  const data = readJson<MembersFile>("members");
+  return [...data.allMembers, ...data.previousMembers].some((m) => m.id === id);
+}
+
+// Uploads land as <id>.jpg in the volume dir; sharp decoding doubles as the
+// file type check and strips whatever metadata the original carried.
+export async function POST(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+  const id = params.id;
+  if (!/^[a-z0-9-]+$/.test(id) || !knownMember(id)) {
+    return NextResponse.json({ error: "Fant ikke medlemmet" }, { status: 404 });
+  }
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Mangler fil" }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Bildet er for stort (maks 5 MB)" },
+      { status: 400 },
+    );
+  }
+
+  let processed: Buffer;
+  try {
+    processed = await sharp(Buffer.from(await file.arrayBuffer()))
+      .rotate()
+      .resize(1200, 1200, { fit: "inside", withoutEnlargement: true })
+      .jpeg({ quality: 85 })
+      .toBuffer();
+  } catch {
+    return NextResponse.json(
+      { error: "Filen er ikke et gyldig bilde" },
+      { status: 400 },
+    );
+  }
+
+  const dir = uploadImageDir();
+  fs.mkdirSync(dir, { recursive: true });
+  // drop stale copies in other formats so the new jpg is the one that resolves
+  for (const ext of IMAGE_EXTENSIONS) {
+    if (ext !== ".jpg") fs.rmSync(path.join(dir, id + ext), { force: true });
+  }
+  fs.writeFileSync(path.join(dir, id + ".jpg"), processed);
+  return NextResponse.json({ image: `/api/members/${id}.jpg` });
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+  const id = params.id;
+  if (!/^[a-z0-9-]+$/.test(id)) {
+    return NextResponse.json({ error: "Ugyldig id" }, { status: 400 });
+  }
+
+  const dir = uploadImageDir();
+  let removed = false;
+  for (const ext of IMAGE_EXTENSIONS) {
+    const full = path.join(dir, id + ext);
+    if (fs.existsSync(full)) {
+      fs.rmSync(full);
+      removed = true;
+    }
+  }
+  if (removed) return NextResponse.json({ ok: true });
+
+  const inRepo = IMAGE_EXTENSIONS.some((ext) =>
+    fs.existsSync(path.join(process.cwd(), "public", "members", id + ext)),
+  );
+  if (inRepo) {
+    return NextResponse.json(
+      { error: "Portrettet ligger i repoet og kan bare fjernes derfra" },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ error: "Fant ikke noe portrett" }, { status: 404 });
+}

--- a/src/app/api/admin/members/[id]/route.ts
+++ b/src/app/api/admin/members/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import type { Member, MembersFile } from "@/data/members";
+import { memberFields } from "../helpers";
+
+type Params = { params: { id: string } };
+
+function findMember(data: MembersFile, id: string): Member | undefined {
+  return [...data.allMembers, ...data.previousMembers].find((m) => m.id === id);
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const parsed = memberFields(body);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const data = readJson<MembersFile>("members");
+  const member = findMember(data, params.id);
+  if (!member) {
+    return NextResponse.json({ error: "Fant ikke medlemmet" }, { status: 404 });
+  }
+
+  Object.assign(member, parsed.value);
+  // endYear: null clears it, which moves the person back to current members.
+  if ((body as Record<string, unknown>).endYear === null) delete member.endYear;
+  if (member.linkedin === "") delete member.linkedin;
+  writeJson("members", data);
+  return NextResponse.json(member);
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const data = readJson<MembersFile>("members");
+  if (!findMember(data, params.id)) {
+    return NextResponse.json({ error: "Fant ikke medlemmet" }, { status: 404 });
+  }
+  data.allMembers = data.allMembers.filter((m) => m.id !== params.id);
+  data.previousMembers = data.previousMembers.filter(
+    (m) => m.id !== params.id,
+  );
+  writeJson("members", data);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/members/helpers.test.ts
+++ b/src/app/api/admin/members/helpers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { memberFields, slugify } from "./helpers";
+
+describe("slugify", () => {
+  it("transliterates norwegian letters", () => {
+    expect(slugify("Kaja Sætherhaug Dalåmo")).toBe("kaja-saetherhaug-dalamo");
+    expect(slugify("Bjørn Ødegård")).toBe("bjorn-odegard");
+  });
+
+  it("strips other diacritics and symbols", () => {
+    expect(slugify("Tri Tác Lê")).toBe("tri-tac-le");
+    expect(slugify("  A.  B!  ")).toBe("a-b");
+  });
+});
+
+describe("memberFields", () => {
+  it("keeps only the editable fields", () => {
+    const parsed = memberFields({
+      name: " Kari ",
+      role: "Leder",
+      id: "hacked",
+      image: "https://evil/x.jpg",
+      startYear: 2025,
+    });
+    expect(parsed).toEqual({
+      value: { name: "Kari", role: "Leder", startYear: 2025 },
+    });
+  });
+
+  it("rejects wrong types and out of range years", () => {
+    expect(memberFields({ name: 42 })).toHaveProperty("error");
+    expect(memberFields({ startYear: 1999 })).toHaveProperty("error");
+    expect(memberFields({ endYear: "ikke et tall" })).toHaveProperty("error");
+  });
+
+  it("ignores empty year strings", () => {
+    expect(memberFields({ endYear: "" })).toEqual({ value: {} });
+  });
+});

--- a/src/app/api/admin/members/helpers.ts
+++ b/src/app/api/admin/members/helpers.ts
@@ -1,0 +1,47 @@
+import type { Member } from "@/data/members";
+
+// Member ids follow the portrait file convention: lowercase ascii slug of the
+// name, æøå transliterated (tri-tac-le, kaja-saetherhaug-dalamo).
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/æ/g, "ae")
+    .replace(/ø/g, "o")
+    .replace(/å/g, "a")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const MAX_LEN = 200;
+const STRING_KEYS = ["name", "role", "studie", "linkedin"] as const;
+const YEAR_KEYS = ["startYear", "endYear"] as const;
+
+// Picks the editable fields out of a request body. Unknown keys are dropped,
+// so a payload can never set id or image directly. Returns an error message
+// instead of a value when a present field has the wrong shape.
+export function memberFields(
+  body: unknown,
+): { value: Partial<Member> } | { error: string } {
+  const src = (body ?? {}) as Record<string, unknown>;
+  const out: Partial<Member> = {};
+  for (const key of STRING_KEYS) {
+    const v = src[key];
+    if (v === undefined || v === null) continue;
+    if (typeof v !== "string" || v.length > MAX_LEN) {
+      return { error: `Ugyldig verdi for ${key}` };
+    }
+    out[key] = v.trim();
+  }
+  for (const key of YEAR_KEYS) {
+    const v = src[key];
+    if (v === undefined || v === null || v === "") continue;
+    const n = Number(v);
+    if (!Number.isInteger(n) || n < 2000 || n > 2100) {
+      return { error: `Ugyldig verdi for ${key}` };
+    }
+    out[key] = n;
+  }
+  return { value: out };
+}

--- a/src/app/api/admin/members/route.test.ts
+++ b/src/app/api/admin/members/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+import { createToken, SESSION_COOKIE } from "@/lib/auth-token";
+
+const URL_ = "http://localhost:3000/api/admin/members";
+
+async function sessionCookie(email: string): Promise<string> {
+  return `${SESSION_COOKIE}=${await createToken(email, "session")}`;
+}
+
+beforeEach(() => {
+  process.env.AUTH_SECRET = "test-secret";
+  process.env.ADMIN_EMAILS = "forvalter@tihlde.org";
+});
+
+afterEach(() => {
+  delete process.env.AUTH_SECRET;
+  delete process.env.ADMIN_EMAILS;
+});
+
+describe("admin members auth gate", () => {
+  it("rejects requests without a session cookie", async () => {
+    expect((await GET(new NextRequest(URL_))).status).toBe(401);
+    const res = await POST(new NextRequest(URL_, { method: "POST" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a session for an email no longer on the allowlist", async () => {
+    const cookie = await sessionCookie("fjernet@tihlde.org");
+    const res = await GET(new NextRequest(URL_, { headers: { cookie } }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects writes from a foreign origin even with a valid session", async () => {
+    const cookie = await sessionCookie("forvalter@tihlde.org");
+    const res = await POST(
+      new NextRequest(URL_, {
+        method: "POST",
+        headers: { cookie, origin: "https://angriper.example" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts writes when the Origin matches the Host header", async () => {
+    const cookie = await sessionCookie("forvalter@tihlde.org");
+    const res = await POST(
+      new NextRequest(URL_, {
+        method: "POST",
+        // invalid body: reaching 400 proves the request passed the auth and
+        // origin gates without writing anything
+        body: "ikke json",
+        headers: {
+          cookie,
+          origin: "http://localhost:3000",
+          host: "localhost:3000",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("lets an allowlisted session read", async () => {
+    const cookie = await sessionCookie("forvalter@tihlde.org");
+    const res = await GET(new NextRequest(URL_, { headers: { cookie } }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.allMembers)).toBe(true);
+  });
+});

--- a/src/app/api/admin/members/route.ts
+++ b/src/app/api/admin/members/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import type { Member, MembersFile } from "@/data/members";
+import { memberFields, slugify } from "./helpers";
+
+// Raw members file for the admin UI, both current and previous members.
+export async function GET(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+  return NextResponse.json(readJson<MembersFile>("members"));
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const parsed = memberFields(body);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+  const { name, role, studie, startYear, endYear, linkedin } = parsed.value;
+  if (!name || !role || !studie || !startYear) {
+    return NextResponse.json(
+      { error: "Navn, rolle, studie og startår er påkrevd" },
+      { status: 400 },
+    );
+  }
+
+  const id = slugify(name);
+  if (!id) {
+    return NextResponse.json({ error: "Ugyldig navn" }, { status: 400 });
+  }
+  const data = readJson<MembersFile>("members");
+  const taken = [...data.allMembers, ...data.previousMembers].some(
+    (m) => m.id === id,
+  );
+  if (taken) {
+    return NextResponse.json(
+      { error: `Det finnes allerede et medlem med id ${id}` },
+      { status: 409 },
+    );
+  }
+
+  const member: Member = {
+    id,
+    name,
+    role,
+    studie,
+    startYear,
+    image: "",
+    ...(endYear ? { endYear } : {}),
+    ...(linkedin ? { linkedin } : {}),
+  };
+  if (member.endYear) data.previousMembers.push(member);
+  else data.allMembers.push(member);
+  writeJson("members", data);
+  return NextResponse.json(member, { status: 201 });
+}

--- a/src/app/api/admin/reports/[index]/route.ts
+++ b/src/app/api/admin/reports/[index]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import { reportFields, type ContentFile } from "../helpers";
+
+type Params = { params: { index: string } };
+
+function entryAt(content: ContentFile, raw: string): number {
+  const i = Number(raw);
+  if (!Number.isInteger(i) || i < 0 || i >= content.reports.length) return -1;
+  return i;
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const parsed = reportFields(body);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const content = readJson<ContentFile>("content");
+  const i = entryAt(content, params.index);
+  if (i < 0) {
+    return NextResponse.json({ error: "Fant ikke raden" }, { status: 404 });
+  }
+  Object.assign(content.reports[i], parsed.value);
+  writeJson("content", content);
+  return NextResponse.json(content.reports[i]);
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const content = readJson<ContentFile>("content");
+  const i = entryAt(content, params.index);
+  if (i < 0) {
+    return NextResponse.json({ error: "Fant ikke raden" }, { status: 404 });
+  }
+  content.reports.splice(i, 1);
+  writeJson("content", content);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/reports/helpers.ts
+++ b/src/app/api/admin/reports/helpers.ts
@@ -1,0 +1,29 @@
+export interface ReportEntry {
+  title: string;
+  url: string;
+  type: string;
+}
+
+export interface ContentFile {
+  reports: ReportEntry[];
+}
+
+// Validates a full or partial report entry from a request body.
+export function reportFields(
+  body: unknown,
+): { value: Partial<ReportEntry> } | { error: string } {
+  const src = (body ?? {}) as Record<string, unknown>;
+  const out: Partial<ReportEntry> = {};
+  for (const key of ["title", "url", "type"] as const) {
+    const v = src[key];
+    if (v === undefined || v === null) continue;
+    if (typeof v !== "string" || v.length > 500) {
+      return { error: `Ugyldig verdi for ${key}` };
+    }
+    out[key] = v.trim();
+  }
+  if (out.url && !/^(https:\/\/|\/)/.test(out.url)) {
+    return { error: "Lenken må starte med https:// eller /" };
+  }
+  return { value: out };
+}

--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import { reportFields, type ContentFile } from "./helpers";
+
+// Adds a row to the report list on /reports. The PDF itself is uploaded
+// separately via ./upload; entries can also point at external links.
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const parsed = reportFields(body);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+  const { title, url, type } = parsed.value;
+  if (!title || !url || !type) {
+    return NextResponse.json(
+      { error: "Tittel, lenke og kategori er påkrevd" },
+      { status: 400 },
+    );
+  }
+
+  const content = readJson<ContentFile>("content");
+  content.reports.unshift({ title, url, type });
+  writeJson("content", content);
+  return NextResponse.json({ title, url, type }, { status: 201 });
+}

--- a/src/app/api/admin/reports/upload/route.ts
+++ b/src/app/api/admin/reports/upload/route.ts
@@ -1,0 +1,42 @@
+import fs from "fs";
+import path from "path";
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { getDataDir } from "@/lib/data-store";
+import { slugify } from "../../members/helpers";
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Mangler fil" }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Filen er for stor (maks 10 MB)" },
+      { status: 400 },
+    );
+  }
+
+  const stem = slugify(path.basename(file.name).replace(/\.pdf$/i, ""));
+  if (!stem) {
+    return NextResponse.json({ error: "Ugyldig filnavn" }, { status: 400 });
+  }
+
+  const data = Buffer.from(await file.arrayBuffer());
+  if (!data.subarray(0, 5).toString("latin1").startsWith("%PDF-")) {
+    return NextResponse.json(
+      { error: "Filen er ikke en gyldig PDF" },
+      { status: 400 },
+    );
+  }
+
+  const dir = path.join(getDataDir(), "reports");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${stem}.pdf`), data);
+  return NextResponse.json({ url: `/api/reports/${stem}.pdf` });
+}

--- a/src/app/api/admin/soknader/[index]/route.ts
+++ b/src/app/api/admin/soknader/[index]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import type { Soknad } from "@/data/soknader";
+import { parseSoknad, sortByDatoDesc } from "../helpers";
+
+type Params = { params: { index: string } };
+
+function rowAt(rows: Soknad[], raw: string): number {
+  const i = Number(raw);
+  if (!Number.isInteger(i) || i < 0 || i >= rows.length) return -1;
+  return i;
+}
+
+// Replaces the whole row; the admin form always sends every field.
+export async function PATCH(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const row = parseSoknad(body);
+  if (!row) {
+    return NextResponse.json(
+      { error: "Ugyldig rad. Alle felt må fylles ut, dato som DD.MM.ÅÅÅÅ" },
+      { status: 400 },
+    );
+  }
+
+  const rows = readJson<Soknad[]>("soknader");
+  const i = rowAt(rows, params.index);
+  if (i < 0) {
+    return NextResponse.json({ error: "Fant ikke raden" }, { status: 404 });
+  }
+  rows[i] = row;
+  writeJson("soknader", sortByDatoDesc(rows));
+  return NextResponse.json(row);
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const rows = readJson<Soknad[]>("soknader");
+  const i = rowAt(rows, params.index);
+  if (i < 0) {
+    return NextResponse.json({ error: "Fant ikke raden" }, { status: 404 });
+  }
+  rows.splice(i, 1);
+  writeJson("soknader", rows);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/soknader/helpers.ts
+++ b/src/app/api/admin/soknader/helpers.ts
@@ -1,0 +1,37 @@
+import type { Soknad } from "@/data/soknader";
+
+const DATO = /^\d{2}\.\d{2}\.\d{4}$/;
+
+function link(v: unknown): { label: string; url: string } | null {
+  const src = (v ?? {}) as Record<string, unknown>;
+  const label = typeof src.label === "string" ? src.label.trim() : "";
+  const url = typeof src.url === "string" ? src.url.trim() : "";
+  if (!label || label.length > 200 || url.length > 500) return null;
+  if (url && !url.startsWith("https://")) return null;
+  return { label, url };
+}
+
+// Validates a complete søknad row. Rows are small enough that partial
+// updates just send the whole row back.
+export function parseSoknad(body: unknown): Soknad | null {
+  const src = (body ?? {}) as Record<string, unknown>;
+  const hvem = typeof src.hvem === "string" ? src.hvem.trim() : "";
+  const hva = typeof src.hva === "string" ? src.hva.trim() : "";
+  const dato = typeof src.dato === "string" ? src.dato.trim() : "";
+  const sokt = link(src.sokt);
+  const resultat = link(src.resultat);
+  const innvilget = (src.resultat as Record<string, unknown>)?.innvilget;
+  if (!hvem || !hva || hvem.length > 200 || hva.length > 200) return null;
+  if (!DATO.test(dato)) return null;
+  if (!sokt || !resultat || typeof innvilget !== "boolean") return null;
+  return { hvem, hva, dato, sokt, resultat: { ...resultat, innvilget } };
+}
+
+function datoValue(dato: string): number {
+  const [d, m, y] = dato.split(".").map(Number);
+  return y * 10000 + m * 100 + d;
+}
+
+export function sortByDatoDesc(rows: Soknad[]): Soknad[] {
+  return [...rows].sort((a, b) => datoValue(b.dato) - datoValue(a.dato));
+}

--- a/src/app/api/admin/soknader/route.ts
+++ b/src/app/api/admin/soknader/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import type { Soknad } from "@/data/soknader";
+import { parseSoknad, sortByDatoDesc } from "./helpers";
+
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const row = parseSoknad(body);
+  if (!row) {
+    return NextResponse.json(
+      { error: "Ugyldig rad. Alle felt må fylles ut, dato som DD.MM.ÅÅÅÅ" },
+      { status: 400 },
+    );
+  }
+
+  const rows = readJson<Soknad[]>("soknader");
+  rows.push(row);
+  writeJson("soknader", sortByDatoDesc(rows));
+  return NextResponse.json(row, { status: 201 });
+}

--- a/src/app/api/auth/request/route.ts
+++ b/src/app/api/auth/request/route.ts
@@ -12,9 +12,19 @@ const RESPONSE = {
   message: "Hvis adressen er autorisert, er en innloggingslenke sendt.",
 };
 
+// The link base must come from config, not from the Host header: a forged
+// Host would otherwise end up in the mailed link and leak the login token to
+// whoever controls that domain (reset-link poisoning). The header-derived
+// origin is only a convenience fallback for local dev.
 function baseUrl(request: Request): string {
+  const configured = process.env.APP_BASE_URL;
+  if (configured) return configured.replace(/\/+$/, "");
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("APP_BASE_URL is not set");
+  }
   const url = new URL(request.url);
-  const proto = request.headers.get("x-forwarded-proto") ?? url.protocol.replace(":", "");
+  const proto =
+    request.headers.get("x-forwarded-proto") ?? url.protocol.replace(":", "");
   return `${proto}://${url.host}`;
 }
 

--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { readJson } from "@/lib/data-store";
 
+// Volume-first data: without this the route is static-optimized at build
+// time and admin edits never show.
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   return NextResponse.json(readJson("content"));
 }

--- a/src/app/api/reports/[file]/route.test.ts
+++ b/src/app/api/reports/[file]/route.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { GET } from "./route";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "fondet-reports-"));
+  process.env.DATA_DIR = dir;
+  fs.mkdirSync(path.join(dir, "reports"));
+  fs.writeFileSync(
+    path.join(dir, "reports", "arsrapport-2025.pdf"),
+    "%PDF-1.4 test",
+  );
+});
+
+afterEach(() => {
+  delete process.env.DATA_DIR;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function get(file: string) {
+  return GET(new Request("http://localhost/api/reports/x"), {
+    params: { file },
+  });
+}
+
+describe("GET /api/reports/[file]", () => {
+  it("serves an uploaded pdf", async () => {
+    const res = await get("arsrapport-2025.pdf");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/pdf");
+    expect(await res.text()).toContain("%PDF");
+  });
+
+  it("404s for missing files and non-pdf names", async () => {
+    expect((await get("finnes-ikke.pdf")).status).toBe(404);
+    expect((await get("arsrapport-2025.txt")).status).toBe(404);
+  });
+
+  it("blocks path traversal", async () => {
+    fs.writeFileSync(path.join(dir, "hemmelig.pdf"), "%PDF topp hemmelig");
+    expect((await get("../hemmelig.pdf")).status).toBe(404);
+    expect((await get("..%2Fhemmelig.pdf")).status).toBe(404);
+    expect((await get("%2e%2e/hemmelig.pdf")).status).toBe(404);
+  });
+});

--- a/src/app/api/reports/[file]/route.ts
+++ b/src/app/api/reports/[file]/route.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+import { getDataDir } from "@/lib/data-store";
+
+// Serves PDFs uploaded through the admin area from the volume. Committed
+// reports under public/reports are served statically and never hit this route.
+export async function GET(
+  _req: Request,
+  { params }: { params: { file: string } },
+) {
+  const safe = path.basename(params.file);
+  if (!/^[a-z0-9._-]+\.pdf$/i.test(safe)) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const dir = path.join(getDataDir(), "reports");
+  const full = path.join(dir, safe);
+  if (!full.startsWith(path.resolve(dir)) || !fs.existsSync(full)) {
+    return new Response("Not found", { status: 404 });
+  }
+  const data = await fs.promises.readFile(full);
+  return new Response(new Uint8Array(data), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${safe}"`,
+      "Cache-Control": "public, max-age=3600, must-revalidate",
+    },
+  });
+}

--- a/src/app/api/soknader/route.ts
+++ b/src/app/api/soknader/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { readJson } from "@/lib/data-store";
 import type { Soknad } from "@/data/soknader";
 
+// Volume-first data: without this the route is static-optimized at build
+// time and admin edits never show.
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   return NextResponse.json(readJson<Soknad[]>("soknader"));
 }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,7 +2,18 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Search, ArrowRight, Home, FileText, Users, Send, Sun, Moon, Monitor } from "lucide-react";
+import {
+  Search,
+  ArrowRight,
+  Home,
+  FileText,
+  Users,
+  Send,
+  Sun,
+  Moon,
+  Monitor,
+  CornerDownLeft,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTheme } from "@/components/providers/ThemeProvider";
 
@@ -11,9 +22,58 @@ type Command = {
   label: string;
   hint: string;
   keywords: string;
+  group: string;
   icon: LucideIcon;
   run: () => void;
 };
+
+// Order the groups appear in the list. Results stay grouped so navigation and
+// theme actions never get shuffled together.
+const GROUP_ORDER = ["Sider", "Tema"];
+
+// Subsequence fuzzy match: every query char must appear in order. Consecutive
+// hits and hits at the start of a word score higher, so "omf" ranks "Om
+// fondet" above a scattered match. Returns the hit positions for highlighting,
+// or null when the query does not fit.
+function fuzzy(query: string, text: string): { score: number; hits: number[] } | null {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  const hits: number[] = [];
+  let qi = 0;
+  let streak = 0;
+  let score = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      hits.push(ti);
+      streak += 1;
+      score += streak * 2;
+      if (ti === 0 || t[ti - 1] === " ") score += 5;
+      qi += 1;
+    } else {
+      streak = 0;
+    }
+  }
+  if (qi < q.length) return null;
+  return { score: score - t.length * 0.1, hits };
+}
+
+function Highlight({ text, hits }: { text: string; hits: number[] }) {
+  if (hits.length === 0) return <>{text}</>;
+  const set = new Set(hits);
+  return (
+    <>
+      {text.split("").map((ch, i) =>
+        set.has(i) ? (
+          <span key={i} className="text-accent font-semibold">
+            {ch}
+          </span>
+        ) : (
+          <span key={i}>{ch}</span>
+        ),
+      )}
+    </>
+  );
+}
 
 export default function CommandPalette() {
   const router = useRouter();
@@ -34,26 +94,51 @@ export default function CommandPalette() {
       setOpen(false);
       router.push(path);
     };
+    const theme = (t: "light" | "dark" | "system") => () => {
+      setTheme(t);
+      setOpen(false);
+    };
     return [
-      { id: "home", label: "Forsiden", hint: "Oversikt og live tall", keywords: "hjem start portefolje dashboard", icon: Home, run: go("/") },
-      { id: "about", label: "Om fondet", hint: "Hva Fondet er", keywords: "about historie", icon: FileText, run: go("/about") },
-      { id: "reports", label: "Rapporter", hint: "Kvartals- og arsrapporter", keywords: "reports kvartal arsrapport dokumenter soknader", icon: FileText, run: go("/reports") },
-      { id: "group", label: "Forvaltningsgruppen", hint: "Medlemmer", keywords: "group gruppe medlemmer team", icon: Users, run: go("/group") },
-      { id: "group-prev", label: "Tidligere medlemmer", hint: "Arkiv", keywords: "tidligere alumni historikk", icon: Users, run: go("/group/tidligere") },
-      { id: "apply", label: "Søk om støtte", hint: "Slik søker du", keywords: "apply soknad stotte penger", icon: Send, run: go("/apply") },
-      { id: "apply-form", label: "Søknadsskjema", hint: "Fyll ut og send", keywords: "skjema form soknad", icon: Send, run: go("/apply/skjema") },
-      { id: "theme-light", label: "Lyst tema", hint: "Bytt utseende", keywords: "theme lys light dag", icon: Sun, run: () => { setTheme("light"); setOpen(false); } },
-      { id: "theme-dark", label: "Mørkt tema", hint: "Bytt utseende", keywords: "theme mork dark natt", icon: Moon, run: () => { setTheme("dark"); setOpen(false); } },
-      { id: "theme-system", label: "Systemtema", hint: "Følg operativsystemet", keywords: "theme system auto", icon: Monitor, run: () => { setTheme("system"); setOpen(false); } },
+      { id: "home", label: "Forsiden", hint: "Oversikt og live tall", keywords: "hjem start portefolje dashboard", group: "Sider", icon: Home, run: go("/") },
+      { id: "about", label: "Om fondet", hint: "Hva Fondet er", keywords: "about historie vedtekter", group: "Sider", icon: FileText, run: go("/about") },
+      { id: "reports", label: "Rapporter", hint: "Kvartals- og årsrapporter", keywords: "reports kvartal arsrapport dokumenter", group: "Sider", icon: FileText, run: go("/reports") },
+      { id: "group", label: "Forvaltningsgruppen", hint: "Medlemmer", keywords: "group gruppe medlemmer team", group: "Sider", icon: Users, run: go("/group") },
+      { id: "group-prev", label: "Tidligere medlemmer", hint: "Arkiv", keywords: "tidligere alumni historikk", group: "Sider", icon: Users, run: go("/group/tidligere") },
+      { id: "apply", label: "Søk om støtte", hint: "Slik søker du", keywords: "apply soknad stotte penger", group: "Sider", icon: Send, run: go("/apply") },
+      { id: "apply-form", label: "Søknadsskjema", hint: "Fyll ut og send", keywords: "skjema form soknad", group: "Sider", icon: Send, run: go("/apply/skjema") },
+      { id: "theme-light", label: "Lyst tema", hint: "Bytt utseende", keywords: "theme lys light dag", group: "Tema", icon: Sun, run: theme("light") },
+      { id: "theme-dark", label: "Mørkt tema", hint: "Bytt utseende", keywords: "theme mork dark natt", group: "Tema", icon: Moon, run: theme("dark") },
+      { id: "theme-system", label: "Systemtema", hint: "Følg operativsystemet", keywords: "theme system auto", group: "Tema", icon: Monitor, run: theme("system") },
     ];
   }, [router, setTheme]);
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return commands;
-    return commands.filter(
-      (c) => c.label.toLowerCase().includes(q) || c.keywords.includes(q),
-    );
+  // Rank by fuzzy score across label, hint and keywords. Label hits drive the
+  // highlight; a match found only in keywords still lists the item, just
+  // without highlighting. With no query the list keeps its authored order.
+  const results = useMemo(() => {
+    const q = query.trim();
+    const scored = commands
+      .map((c) => {
+        if (!q) return { c, score: 0, hits: [] as number[] };
+        const inLabel = fuzzy(q, c.label);
+        const inHint = fuzzy(q, c.hint);
+        const inKw = fuzzy(q, c.keywords);
+        const best = [inLabel, inHint, inKw]
+          .filter((m): m is { score: number; hits: number[] } => m !== null)
+          .sort((a, b) => b.score - a.score)[0];
+        if (!best) return null;
+        return {
+          c,
+          score: best.score + (inLabel ? 3 : 0),
+          hits: inLabel?.hits ?? [],
+        };
+      })
+      .filter((r): r is { c: Command; score: number; hits: number[] } => r !== null);
+
+    if (q) scored.sort((a, b) => b.score - a.score);
+    // Flatten into the fixed group order so the visible order matches the
+    // index the arrow keys walk through.
+    return GROUP_ORDER.flatMap((g) => scored.filter((r) => r.c.group === g));
   }, [commands, query]);
 
   // Global shortcut: Cmd/Ctrl+K toggles the palette.
@@ -113,22 +198,24 @@ export default function CommandPalette() {
   const onInputKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setActive((i) => Math.min(i + 1, filtered.length - 1));
+      setActive((i) => Math.min(i + 1, results.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setActive((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      filtered[active]?.run();
+      results[active]?.c.run();
     } else if (e.key === "Escape") {
       e.preventDefault();
       setOpen(false);
     }
   };
 
+  let flatIndex = -1;
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 px-4 pt-[15vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 px-4 pt-[15vh] backdrop-blur-sm"
       onClick={() => setOpen(false)}
     >
       <div
@@ -150,7 +237,7 @@ export default function CommandPalette() {
             aria-expanded="true"
             aria-controls="cmd-listbox"
             aria-activedescendant={
-              filtered[active] ? `cmd-opt-${active}` : undefined
+              results[active] ? `cmd-opt-${active}` : undefined
             }
             aria-autocomplete="list"
             placeholder="Søk sider og handlinger…"
@@ -159,45 +246,78 @@ export default function CommandPalette() {
         </div>
 
         <ul id="cmd-listbox" role="listbox" className="max-h-80 overflow-y-auto py-2">
-          {filtered.length === 0 && (
-            <li className="px-4 py-6 text-center text-sm text-foreground-secondary">
-              Ingen treff
+          {results.length === 0 && (
+            <li className="px-4 py-8 text-center text-sm text-foreground-secondary">
+              Ingen treff for «{query.trim()}»
             </li>
           )}
-          {filtered.map((c, i) => {
-            const Icon = c.icon;
-            const selected = i === active;
+          {GROUP_ORDER.map((group) => {
+            const inGroup = results.filter((r) => r.c.group === group);
+            if (inGroup.length === 0) return null;
             return (
-              <li
-                key={c.id}
-                id={`cmd-opt-${i}`}
-                role="option"
-                aria-selected={selected}
-                onMouseEnter={() => setActive(i)}
-                onClick={c.run}
-                className={`mx-2 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 ${
-                  selected ? "bg-cardBorder/50" : ""
-                }`}
-              >
-                <Icon className="h-4 w-4 text-accent shrink-0" aria-hidden />
-                <span className="flex-1 min-w-0">
-                  <span className="block truncate text-sm text-foreground-primary">
-                    {c.label}
-                  </span>
-                  <span className="block truncate text-xs text-foreground-secondary">
-                    {c.hint}
-                  </span>
-                </span>
-                {selected && (
-                  <ArrowRight
-                    className="h-4 w-4 text-foreground-secondary shrink-0"
-                    aria-hidden
-                  />
-                )}
+              <li key={group} role="presentation">
+                <div className="px-4 pt-2 pb-1 text-xs font-semibold uppercase tracking-wide text-foreground-secondary">
+                  {group}
+                </div>
+                <ul role="presentation">
+                  {inGroup.map((r) => {
+                    flatIndex += 1;
+                    const i = flatIndex;
+                    const Icon = r.c.icon;
+                    const selected = i === active;
+                    return (
+                      <li
+                        key={r.c.id}
+                        id={`cmd-opt-${i}`}
+                        role="option"
+                        aria-selected={selected}
+                        onMouseEnter={() => setActive(i)}
+                        onClick={r.c.run}
+                        className={`mx-2 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 ${
+                          selected ? "bg-cardBorder/50" : ""
+                        }`}
+                      >
+                        <Icon className="h-4 w-4 text-accent shrink-0" aria-hidden />
+                        <span className="flex-1 min-w-0">
+                          <span className="block truncate text-sm text-foreground-primary">
+                            <Highlight text={r.c.label} hits={r.hits} />
+                          </span>
+                          <span className="block truncate text-xs text-foreground-secondary">
+                            {r.c.hint}
+                          </span>
+                        </span>
+                        {selected && (
+                          <ArrowRight
+                            className="h-4 w-4 text-foreground-secondary shrink-0"
+                            aria-hidden
+                          />
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
               </li>
             );
           })}
         </ul>
+
+        <div className="flex items-center gap-4 border-t border-cardBorder px-4 py-2 text-xs text-foreground-secondary">
+          <span className="inline-flex items-center gap-1">
+            <kbd className="rounded border border-cardBorder px-1">↑</kbd>
+            <kbd className="rounded border border-cardBorder px-1">↓</kbd>
+            naviger
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <kbd className="rounded border border-cardBorder px-1">
+              <CornerDownLeft className="h-3 w-3" aria-hidden />
+            </kbd>
+            velg
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <kbd className="rounded border border-cardBorder px-1">esc</kbd>
+            lukk
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/admin/GroupImagesAdmin.tsx
+++ b/src/components/admin/GroupImagesAdmin.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api, jsonInit, errorMessage } from "./api";
+
+type GroupImage = { file: string; url: string; source: "volume" | "repo" };
+
+export default function GroupImagesAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["admin-group-images"],
+    queryFn: () => api<{ images: GroupImage[] }>("/api/admin/group-images"),
+  });
+  const [name, setName] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function refresh() {
+    await qc.invalidateQueries({ queryKey: ["admin-group-images"] });
+  }
+
+  async function upload(e: React.FormEvent) {
+    e.preventDefault();
+    if (!file) {
+      toast.error("Velg en fil først");
+      return;
+    }
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append("name", name);
+      fd.append("file", file);
+      await api("/api/admin/group-images", { method: "POST", body: fd });
+      await refresh();
+      toast.success("Gruppebilde lastet opp");
+      setName("");
+      setFile(null);
+      (document.getElementById("group-image-file") as HTMLInputElement | null)?.form?.reset();
+    } catch (err) {
+      toast.error(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(img: GroupImage) {
+    if (!confirm(`Slette ${img.file}? Dette kan ikke angres.`)) return;
+    setBusy(true);
+    try {
+      await api("/api/admin/group-images", jsonInit("DELETE", { file: img.file }));
+      await refresh();
+      toast.success("Bilde slettet");
+    } catch (err) {
+      toast.error(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section aria-labelledby="admin-group-images-heading">
+      <h2 id="admin-group-images-heading" className="text-2xl font-bold text-foreground-primary mb-2">
+        Gruppebilder
+      </h2>
+      <p className="text-foreground-secondary mb-4">
+        group og group-2 til group-9 vises i karusellen på gruppesiden.
+        group-ÅÅÅÅ-N, for eksempel group-2024-1, havner i arkivet på siden for
+        tidligere medlemmer.
+      </p>
+
+      <form onSubmit={upload} className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="group-image-name" className="block text-sm font-semibold text-foreground-primary mb-1">
+              Navn
+            </label>
+            <Input
+              id="group-image-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="group, group-2 eller group-2024-1"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="group-image-file" className="block text-sm font-semibold text-foreground-primary mb-1">
+              Bildefil (jpg, png eller webp)
+            </label>
+            <input
+              id="group-image-file"
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className="text-sm text-foreground-secondary py-2"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              required
+            />
+          </div>
+        </div>
+        <Button type="submit" disabled={busy} className="mt-4">
+          Last opp
+        </Button>
+      </form>
+
+      {isLoading && <p className="text-foreground-secondary">Laster bilder ...</p>}
+      {isError && (
+        <p role="alert" className="text-red-500">
+          Kunne ikke laste gruppebildene. Prøv igjen senere.
+        </p>
+      )}
+
+      <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {(data?.images ?? []).map((img) => (
+          <li key={img.file} className="bg-cardBackground border border-cardBorder rounded-lg p-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={img.url} alt={`Gruppebilde ${img.file}`} className="w-full h-32 object-cover rounded" />
+            <p className="text-sm text-foreground-primary mt-2 break-all">{img.file}</p>
+            <p className="text-xs text-foreground-secondary mb-2">
+              {img.source === "volume" ? "Lastet opp" : "Ligger i repoet"}
+            </p>
+            {img.source === "volume" ? (
+              <Button type="button" variant="destructive" className="min-h-[44px] w-full" onClick={() => remove(img)} disabled={busy}>
+                Slett
+              </Button>
+            ) : (
+              <p className="text-xs text-foreground-secondary">Kan bare fjernes fra repoet</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/MembersAdmin.tsx
+++ b/src/components/admin/MembersAdmin.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { Member, MembersFile } from "@/data/members";
+import { api, jsonInit, errorMessage } from "./api";
+
+type FormState = {
+  name: string;
+  role: string;
+  studie: string;
+  startYear: string;
+  endYear: string;
+  linkedin: string;
+};
+
+const EMPTY: FormState = {
+  name: "",
+  role: "",
+  studie: "",
+  startYear: "",
+  endYear: "",
+  linkedin: "",
+};
+
+function toForm(m: Member): FormState {
+  return {
+    name: m.name,
+    role: m.role,
+    studie: m.studie,
+    startYear: String(m.startYear),
+    endYear: m.endYear ? String(m.endYear) : "",
+    linkedin: m.linkedin ?? "",
+  };
+}
+
+function Field({
+  id,
+  label,
+  value,
+  onChange,
+  type = "text",
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-sm font-semibold text-foreground-primary mb-1"
+      >
+        {label}
+      </label>
+      <Input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function MemberForm({
+  idPrefix,
+  form,
+  setForm,
+}: {
+  idPrefix: string;
+  form: FormState;
+  setForm: (f: FormState) => void;
+}) {
+  const set = (key: keyof FormState) => (v: string) =>
+    setForm({ ...form, [key]: v });
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <Field id={`${idPrefix}-name`} label="Navn" value={form.name} onChange={set("name")} />
+      <Field id={`${idPrefix}-role`} label="Rolle" value={form.role} onChange={set("role")} />
+      <Field id={`${idPrefix}-studie`} label="Studie" value={form.studie} onChange={set("studie")} />
+      <Field id={`${idPrefix}-linkedin`} label="LinkedIn-lenke" value={form.linkedin} onChange={set("linkedin")} />
+      <Field id={`${idPrefix}-start`} label="Startår" type="number" value={form.startYear} onChange={set("startYear")} />
+      <Field id={`${idPrefix}-end`} label="Sluttår (tomt for aktive)" type="number" value={form.endYear} onChange={set("endYear")} />
+    </div>
+  );
+}
+
+export default function MembersAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["admin-members"],
+    queryFn: () => api<MembersFile>("/api/admin/members"),
+  });
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [showNew, setShowNew] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const members = data
+    ? [...data.allMembers, ...data.previousMembers].sort((a, b) => {
+        if (!a.endYear !== !b.endYear) return a.endYear ? 1 : -1;
+        if (a.endYear && b.endYear) return b.endYear - a.endYear;
+        return a.startYear - b.startYear;
+      })
+    : [];
+
+  async function run(action: () => Promise<unknown>, done: string) {
+    setBusy(true);
+    try {
+      await action();
+      await qc.invalidateQueries({ queryKey: ["admin-members"] });
+      toast.success(done);
+      return true;
+    } catch (err) {
+      toast.error(errorMessage(err));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function body(patch: boolean) {
+    return {
+      name: form.name,
+      role: form.role,
+      studie: form.studie,
+      linkedin: form.linkedin,
+      startYear: form.startYear ? Number(form.startYear) : undefined,
+      endYear: form.endYear ? Number(form.endYear) : patch ? null : undefined,
+    };
+  }
+
+  async function create() {
+    if (await run(() => api("/api/admin/members", jsonInit("POST", body(false))), "Medlem lagt til")) {
+      setShowNew(false);
+      setForm(EMPTY);
+    }
+  }
+
+  async function save(id: string) {
+    if (await run(() => api(`/api/admin/members/${id}`, jsonInit("PATCH", body(true))), "Medlem oppdatert")) {
+      setEditingId(null);
+    }
+  }
+
+  async function remove(m: Member) {
+    if (!confirm(`Slette ${m.name}? Dette kan ikke angres.`)) return;
+    await run(() => api(`/api/admin/members/${m.id}`, { method: "DELETE" }), "Medlem slettet");
+  }
+
+  async function uploadPortrait(m: Member, file: File) {
+    const fd = new FormData();
+    fd.append("file", file);
+    await run(
+      () => api(`/api/admin/members/${m.id}/portrait`, { method: "POST", body: fd }),
+      `Portrett lastet opp for ${m.name}`,
+    );
+  }
+
+  async function removePortrait(m: Member) {
+    if (!confirm(`Fjerne portrettet til ${m.name}?`)) return;
+    await run(
+      () => api(`/api/admin/members/${m.id}/portrait`, { method: "DELETE" }),
+      "Portrett fjernet",
+    );
+  }
+
+  return (
+    <section aria-labelledby="admin-members-heading">
+      <div className="flex items-center justify-between mb-4">
+        <h2 id="admin-members-heading" className="text-2xl font-bold text-foreground-primary">
+          Medlemmer
+        </h2>
+        <Button
+          type="button"
+          onClick={() => {
+            setShowNew(!showNew);
+            setEditingId(null);
+            setForm(EMPTY);
+          }}
+        >
+          {showNew ? "Avbryt" : "Nytt medlem"}
+        </Button>
+      </div>
+
+      {showNew && (
+        <div className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+          <MemberForm idPrefix="new-member" form={form} setForm={setForm} />
+          <Button type="button" onClick={create} disabled={busy} className="mt-4">
+            Lagre nytt medlem
+          </Button>
+        </div>
+      )}
+
+      {isLoading && <p className="text-foreground-secondary">Laster medlemmer ...</p>}
+      {isError && (
+        <p role="alert" className="text-red-500">
+          Kunne ikke laste medlemmene. Prøv igjen senere.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {members.map((m) => (
+          <li key={m.id} className="bg-cardBackground border border-cardBorder rounded-lg p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="font-semibold text-foreground-primary">
+                  {m.name}
+                  {m.endYear ? (
+                    <span className="font-normal text-foreground-secondary"> (tidligere)</span>
+                  ) : null}
+                </p>
+                <p className="text-sm text-foreground-secondary">
+                  {m.role} - {m.studie} - {m.startYear}
+                  {m.endYear ? ` til ${m.endYear}` : ""}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    if (editingId === m.id) {
+                      setEditingId(null);
+                    } else {
+                      setEditingId(m.id);
+                      setShowNew(false);
+                      setForm(toForm(m));
+                    }
+                  }}
+                >
+                  {editingId === m.id ? "Avbryt" : "Rediger"}
+                </Button>
+                <Button type="button" variant="destructive" className="min-h-[44px] px-4" onClick={() => remove(m)} disabled={busy}>
+                  Slett
+                </Button>
+              </div>
+            </div>
+
+            {editingId === m.id && (
+              <div className="mt-4 border-t border-cardBorder pt-4">
+                <MemberForm idPrefix={`edit-${m.id}`} form={form} setForm={setForm} />
+                <div className="flex flex-wrap items-center gap-4 mt-4">
+                  <Button type="button" onClick={() => save(m.id)} disabled={busy}>
+                    Lagre endringer
+                  </Button>
+                  <div>
+                    <label
+                      htmlFor={`portrait-${m.id}`}
+                      className="block text-sm font-semibold text-foreground-primary mb-1"
+                    >
+                      Last opp portrett (jpg, png eller webp)
+                    </label>
+                    <input
+                      id={`portrait-${m.id}`}
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp"
+                      className="text-sm text-foreground-secondary"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) uploadPortrait(m, file);
+                        e.target.value = "";
+                      }}
+                    />
+                  </div>
+                  <Button type="button" variant="outline" onClick={() => removePortrait(m)} disabled={busy}>
+                    Fjern portrett
+                  </Button>
+                </div>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/ReportsAdmin.tsx
+++ b/src/components/admin/ReportsAdmin.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api, jsonInit, errorMessage } from "./api";
+
+type ReportEntry = { title: string; url: string; type: string };
+type FormState = ReportEntry;
+
+const EMPTY: FormState = { title: "", url: "", type: "" };
+
+function EntryForm({
+  idPrefix,
+  form,
+  setForm,
+  types,
+}: {
+  idPrefix: string;
+  form: FormState;
+  setForm: (f: FormState) => void;
+  types: string[];
+}) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div>
+        <label htmlFor={`${idPrefix}-title`} className="block text-sm font-semibold text-foreground-primary mb-1">
+          Tittel
+        </label>
+        <Input
+          id={`${idPrefix}-title`}
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+        />
+      </div>
+      <div>
+        <label htmlFor={`${idPrefix}-type`} className="block text-sm font-semibold text-foreground-primary mb-1">
+          Kategori
+        </label>
+        <Input
+          id={`${idPrefix}-type`}
+          value={form.type}
+          list="report-types"
+          onChange={(e) => setForm({ ...form, type: e.target.value })}
+        />
+        <datalist id="report-types">
+          {types.map((t) => (
+            <option key={t} value={t} />
+          ))}
+        </datalist>
+      </div>
+      <div>
+        <label htmlFor={`${idPrefix}-url`} className="block text-sm font-semibold text-foreground-primary mb-1">
+          Lenke
+        </label>
+        <Input
+          id={`${idPrefix}-url`}
+          value={form.url}
+          placeholder="/api/reports/... eller https://..."
+          onChange={(e) => setForm({ ...form, url: e.target.value })}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function ReportsAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["admin-content"],
+    queryFn: () => api<{ reports: ReportEntry[] }>("/api/content"),
+  });
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [editing, setEditing] = useState<number | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const reports = data?.reports ?? [];
+  const types = Array.from(new Set(reports.map((r) => r.type)));
+
+  async function run(action: () => Promise<unknown>, done: string) {
+    setBusy(true);
+    try {
+      await action();
+      await qc.invalidateQueries({ queryKey: ["admin-content"] });
+      toast.success(done);
+      return true;
+    } catch (err) {
+      toast.error(errorMessage(err));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function uploadPdf(file: File) {
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const { url } = await api<{ url: string }>("/api/admin/reports/upload", {
+        method: "POST",
+        body: fd,
+      });
+      setForm((f) => ({ ...f, url }));
+      setShowNew(true);
+      setEditing(null);
+      toast.success("PDF lastet opp. Lenken er fylt inn i skjemaet.");
+    } catch (err) {
+      toast.error(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function create() {
+    if (await run(() => api("/api/admin/reports", jsonInit("POST", form)), "Rad lagt til")) {
+      setShowNew(false);
+      setForm(EMPTY);
+    }
+  }
+
+  async function save(index: number) {
+    if (await run(() => api(`/api/admin/reports/${index}`, jsonInit("PATCH", form)), "Rad oppdatert")) {
+      setEditing(null);
+    }
+  }
+
+  async function remove(index: number, entry: ReportEntry) {
+    if (!confirm(`Slette raden "${entry.title}"? Dette kan ikke angres.`)) return;
+    await run(() => api(`/api/admin/reports/${index}`, { method: "DELETE" }), "Rad slettet");
+  }
+
+  return (
+    <section aria-labelledby="admin-reports-heading">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 id="admin-reports-heading" className="text-2xl font-bold text-foreground-primary">
+          Rapporter og dokumenter
+        </h2>
+        <Button
+          type="button"
+          onClick={() => {
+            setShowNew(!showNew);
+            setEditing(null);
+            setForm(EMPTY);
+          }}
+        >
+          {showNew ? "Avbryt" : "Ny rad"}
+        </Button>
+      </div>
+
+      <div className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+        <label htmlFor="report-pdf" className="block text-sm font-semibold text-foreground-primary mb-1">
+          Last opp PDF (maks 10 MB)
+        </label>
+        <input
+          id="report-pdf"
+          type="file"
+          accept="application/pdf"
+          className="text-sm text-foreground-secondary"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) uploadPdf(file);
+            e.target.value = "";
+          }}
+        />
+        <p className="text-xs text-foreground-secondary mt-1">
+          Opplasting fyller inn lenken i radskjemaet. Raden må lagres etterpå
+          for å vises på siden.
+        </p>
+      </div>
+
+      {showNew && (
+        <div className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+          <EntryForm idPrefix="new-report" form={form} setForm={setForm} types={types} />
+          <Button type="button" onClick={create} disabled={busy} className="mt-4">
+            Lagre ny rad
+          </Button>
+        </div>
+      )}
+
+      {isLoading && <p className="text-foreground-secondary">Laster rader ...</p>}
+      {isError && (
+        <p role="alert" className="text-red-500">
+          Kunne ikke laste radene. Prøv igjen senere.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {reports.map((r, i) => (
+          <li key={`${r.title}-${i}`} className="bg-cardBackground border border-cardBorder rounded-lg p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="font-semibold text-foreground-primary">{r.title}</p>
+                <p className="text-sm text-foreground-secondary break-all">
+                  {r.type} - {r.url}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    if (editing === i) {
+                      setEditing(null);
+                    } else {
+                      setEditing(i);
+                      setShowNew(false);
+                      setForm({ title: r.title, url: r.url, type: r.type });
+                    }
+                  }}
+                >
+                  {editing === i ? "Avbryt" : "Rediger"}
+                </Button>
+                <Button type="button" variant="destructive" className="min-h-[44px] px-4" onClick={() => remove(i, r)} disabled={busy}>
+                  Slett
+                </Button>
+              </div>
+            </div>
+            {editing === i && (
+              <div className="mt-4 border-t border-cardBorder pt-4">
+                <EntryForm idPrefix={`edit-report-${i}`} form={form} setForm={setForm} types={types} />
+                <Button type="button" onClick={() => save(i)} disabled={busy} className="mt-4">
+                  Lagre endringer
+                </Button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/SoknaderAdmin.tsx
+++ b/src/components/admin/SoknaderAdmin.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { Soknad } from "@/data/soknader";
+import { api, jsonInit, errorMessage } from "./api";
+
+type FormState = {
+  hvem: string;
+  hva: string;
+  dato: string;
+  soktLabel: string;
+  soktUrl: string;
+  resultatLabel: string;
+  resultatUrl: string;
+  innvilget: boolean;
+};
+
+const EMPTY: FormState = {
+  hvem: "",
+  hva: "",
+  dato: "",
+  soktLabel: "",
+  soktUrl: "",
+  resultatLabel: "",
+  resultatUrl: "",
+  innvilget: true,
+};
+
+function toForm(s: Soknad): FormState {
+  return {
+    hvem: s.hvem,
+    hva: s.hva,
+    dato: s.dato,
+    soktLabel: s.sokt.label,
+    soktUrl: s.sokt.url,
+    resultatLabel: s.resultat.label,
+    resultatUrl: s.resultat.url,
+    innvilget: s.resultat.innvilget,
+  };
+}
+
+function toBody(f: FormState): Soknad {
+  return {
+    hvem: f.hvem,
+    hva: f.hva,
+    dato: f.dato,
+    sokt: { label: f.soktLabel, url: f.soktUrl },
+    resultat: { label: f.resultatLabel, url: f.resultatUrl, innvilget: f.innvilget },
+  };
+}
+
+function SoknadForm({
+  idPrefix,
+  form,
+  setForm,
+}: {
+  idPrefix: string;
+  form: FormState;
+  setForm: (f: FormState) => void;
+}) {
+  const text = (key: keyof FormState, label: string, placeholder = "") => (
+    <div>
+      <label htmlFor={`${idPrefix}-${key}`} className="block text-sm font-semibold text-foreground-primary mb-1">
+        {label}
+      </label>
+      <Input
+        id={`${idPrefix}-${key}`}
+        value={String(form[key])}
+        placeholder={placeholder}
+        onChange={(e) => setForm({ ...form, [key]: e.target.value })}
+      />
+    </div>
+  );
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {text("hvem", "Hvem")}
+      {text("hva", "Hva")}
+      {text("dato", "Dato", "DD.MM.ÅÅÅÅ")}
+      {text("soktLabel", "Søkt beløp")}
+      {text("soktUrl", "Lenke til søknad", "https://...")}
+      {text("resultatLabel", "Resultat")}
+      {text("resultatUrl", "Lenke til vedtak", "https://...")}
+      <div className="flex items-end pb-2">
+        <label className="flex items-center gap-2 text-sm font-semibold text-foreground-primary min-h-[44px]">
+          <input
+            type="checkbox"
+            checked={form.innvilget}
+            onChange={(e) => setForm({ ...form, innvilget: e.target.checked })}
+            className="h-5 w-5"
+          />
+          Innvilget
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export default function SoknaderAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["soknader"],
+    queryFn: () => api<Soknad[]>("/api/soknader"),
+  });
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [editing, setEditing] = useState<number | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const rows = data ?? [];
+
+  async function run(action: () => Promise<unknown>, done: string) {
+    setBusy(true);
+    try {
+      await action();
+      await qc.invalidateQueries({ queryKey: ["soknader"] });
+      toast.success(done);
+      return true;
+    } catch (err) {
+      toast.error(errorMessage(err));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function create() {
+    if (await run(() => api("/api/admin/soknader", jsonInit("POST", toBody(form))), "Søknad lagt til")) {
+      setShowNew(false);
+      setForm(EMPTY);
+    }
+  }
+
+  async function save(index: number) {
+    if (await run(() => api(`/api/admin/soknader/${index}`, jsonInit("PATCH", toBody(form))), "Søknad oppdatert")) {
+      setEditing(null);
+    }
+  }
+
+  async function remove(index: number, row: Soknad) {
+    if (!confirm(`Slette søknaden fra ${row.hvem} (${row.dato})? Dette kan ikke angres.`)) return;
+    await run(() => api(`/api/admin/soknader/${index}`, { method: "DELETE" }), "Søknad slettet");
+  }
+
+  return (
+    <section aria-labelledby="admin-soknader-heading">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 id="admin-soknader-heading" className="text-2xl font-bold text-foreground-primary">
+          Søknader og vedtak
+        </h2>
+        <Button
+          type="button"
+          onClick={() => {
+            setShowNew(!showNew);
+            setEditing(null);
+            setForm(EMPTY);
+          }}
+        >
+          {showNew ? "Avbryt" : "Ny søknad"}
+        </Button>
+      </div>
+
+      {showNew && (
+        <div className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+          <SoknadForm idPrefix="new-soknad" form={form} setForm={setForm} />
+          <Button type="button" onClick={create} disabled={busy} className="mt-4">
+            Lagre ny søknad
+          </Button>
+        </div>
+      )}
+
+      {isLoading && <p className="text-foreground-secondary">Laster søknader ...</p>}
+      {isError && (
+        <p role="alert" className="text-red-500">
+          Kunne ikke laste søknadene. Prøv igjen senere.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {rows.map((s, i) => (
+          <li key={`${s.dato}-${s.hvem}-${i}`} className="bg-cardBackground border border-cardBorder rounded-lg p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="font-semibold text-foreground-primary">
+                  {s.hvem} - {s.hva}
+                </p>
+                <p className="text-sm text-foreground-secondary">
+                  {s.dato} - søkt {s.sokt.label} -{" "}
+                  {s.resultat.innvilget ? "innvilget" : "avslått"} {s.resultat.label}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    if (editing === i) {
+                      setEditing(null);
+                    } else {
+                      setEditing(i);
+                      setShowNew(false);
+                      setForm(toForm(s));
+                    }
+                  }}
+                >
+                  {editing === i ? "Avbryt" : "Rediger"}
+                </Button>
+                <Button type="button" variant="destructive" className="min-h-[44px] px-4" onClick={() => remove(i, s)} disabled={busy}>
+                  Slett
+                </Button>
+              </div>
+            </div>
+            {editing === i && (
+              <div className="mt-4 border-t border-cardBorder pt-4">
+                <SoknadForm idPrefix={`edit-soknad-${i}`} form={form} setForm={setForm} />
+                <Button type="button" onClick={() => save(i)} disabled={busy} className="mt-4">
+                  Lagre endringer
+                </Button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/api.ts
+++ b/src/components/admin/api.ts
@@ -1,0 +1,27 @@
+// Small fetch wrapper for the admin sections: throws the server's Norwegian
+// error message so callers can toast it directly.
+export async function api<T = unknown>(
+  url: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(url, init);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(
+      (data as { error?: string }).error || "Noe gikk galt. Prøv igjen.",
+    );
+  }
+  return data as T;
+}
+
+export function jsonInit(method: string, body: unknown): RequestInit {
+  return {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Noe gikk galt. Prøv igjen.";
+}

--- a/src/lib/member-images.ts
+++ b/src/lib/member-images.ts
@@ -9,16 +9,27 @@
 import fs from "fs";
 import path from "path";
 import type { Member } from "@/data/members";
+import { getDataDir } from "@/lib/data-store";
 
-const EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"];
+export const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"];
+const EXTENSIONS = IMAGE_EXTENSIONS;
 
 const REPO_DIR = path.join(process.cwd(), "public", "members");
 
+// Where admin uploads land: the configured volume, or the data dir when
+// MEMBERS_IMAGE_DIR is unset (local dev).
+export function uploadImageDir(): string {
+  return process.env.MEMBERS_IMAGE_DIR || path.join(getDataDir(), "members");
+}
+
 // Directories searched in order; the volume (if configured) overrides the
-// repo copy, and the repo copy is the fallback.
+// repo copy, and the repo copy is the fallback. The upload dir sits in the
+// middle so local admin uploads resolve without MEMBERS_IMAGE_DIR set.
 export function membersImageDirs(): string[] {
   const dirs: string[] = [];
   if (process.env.MEMBERS_IMAGE_DIR) dirs.push(process.env.MEMBERS_IMAGE_DIR);
+  const uploads = uploadImageDir();
+  if (!dirs.includes(uploads)) dirs.push(uploads);
   dirs.push(REPO_DIR);
   return dirs;
 }

--- a/src/lib/nordnet.ts
+++ b/src/lib/nordnet.ts
@@ -87,7 +87,7 @@ export interface Trade {
 }
 
 const FEED_PAGE_SIZE = 50;
-const FEED_MAX_PAGES = 6;
+const FEED_MAX_PAGES = 30;
 
 export async function getTrades(): Promise<Trade[]> {
   const profile = await getProfile();

--- a/src/lib/require-admin.ts
+++ b/src/lib/require-admin.ts
@@ -1,6 +1,10 @@
-import type { NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { SESSION_COOKIE, verifyToken } from "@/lib/auth-token";
 import { isAllowedEmail } from "@/lib/allowlist";
+
+export function unauthorized(): NextResponse {
+  return NextResponse.json({ error: "Ikke autorisert" }, { status: 401 });
+}
 
 // Gate for the admin API routes. Middleware already guards the /admin pages,
 // but routes re-check here because the allowlist lives on disk and middleware
@@ -13,8 +17,12 @@ export async function requireAdmin(
   if (request.method !== "GET") {
     const origin = request.headers.get("origin");
     if (origin) {
+      // Compare against the Host header, not nextUrl: in the standalone
+      // server nextUrl carries the bind address (0.0.0.0:port), which would
+      // reject every legitimate same-origin request.
+      const host = request.headers.get("host") ?? request.nextUrl.host;
       try {
-        if (new URL(origin).host !== request.nextUrl.host) return null;
+        if (new URL(origin).host !== host) return null;
       } catch {
         return null;
       }


### PR DESCRIPTION
## What

Part 3 of the admin login work (#88, #90): the actual admin area at /admin, gated by the magic-link session.

- Admin API under /api/admin/*, every handler behind requireAdmin (session cookie + allowlist re-read + origin check on writes):
  - members: add, edit, delete; portrait upload (sharp recompress to jpg on the volume) and removal
  - group images: upload/delete with the existing group / group-N / group-YYYY-N naming
  - reports: PDF upload to the volume (served via new public /api/reports/[file] with traversal guard) and CRUD for the rows on /reports
  - soknader: row CRUD, kept sorted newest first
- Admin UI in Norwegian at /admin: four sections, react-query + sonner toasts, confirm before delete, 44px targets
- Also carries the magic-link base URL fix (link base from APP_BASE_URL config instead of the Host header, closes the reset-link poisoning hole)

## Fixes found along the way

- /api/content and /api/soknader were static-optimized at build time, so volume edits would never have shown; both are now force-dynamic
- The CSRF origin check compared against nextUrl.host, which in the standalone server is the bind address (0.0.0.0:port); every legitimate same-origin write got 401. Now compares against the Host header
- e2e site spec still expected the old homepage heading from before #85

## Testing

- 78 vitest tests green (13 new: auth gate incl. forged-origin and allowlist-removal, reports traversal guard, slugify/field whitelist)
- Playwright e2e green (36 tests, new admin spec: anonymous redirect + generic login response)
- Manual smoke against the standalone build: member CRUD incl. æøå slugging, portrait upload/serve/delete, PDF upload/serve, report rows, soknad sorting and validation, forged origin rejected, duplicate id 409