### PR TITLE
fix: retry on failed portfolio fetch, reduced-motion skeletons

### DIFF
--- a/src/components/HoldingsTable.tsx
+++ b/src/components/HoldingsTable.tsx
@@ -149,7 +149,7 @@ function DetailField({ label, value }: { label: string; value: string }) {
 }
 
 export default function HoldingsTable() {
-  const { data, isLoading } = useNordnet();
+  const { data, isLoading, isFetching, refetch } = useNordnet();
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
@@ -211,9 +211,17 @@ export default function HoldingsTable() {
 
   if (raw.length === 0) {
     return (
-      <p className="text-foreground-secondary">
-        Fikk ikke hentet porteføljen fra Nordnet akkurat nå. Prøv igjen senere.
-      </p>
+      <div className="text-foreground-secondary">
+        <p>Fikk ikke hentet porteføljen fra Nordnet akkurat nå.</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          className="mt-3 inline-flex items-center rounded-md border border-cardBorder bg-cardBackground px-4 h-11 text-sm text-foreground-primary transition-colors hover:bg-cardBorder/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground-primary disabled:opacity-60"
+        >
+          {isFetching ? "Prøver igjen..." : "Prøv igjen"}
+        </button>
+      </div>
     );
   }
 

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -6,7 +6,10 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-cardBorder/60", className)}
+      className={cn(
+        "animate-pulse motion-reduce:animate-none rounded-md bg-cardBorder/60",
+        className,
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
Two small recovery and accessibility fixes:

- The holdings failure state said "Prøv igjen senere" with no way to act on it. It now has a Prøv igjen button that refetches the shared nordnet query, disabled with a progress label while the refetch runs.
- Skeleton placeholders respect prefers-reduced-motion and render static instead of pulsing.

Verified: tsc clean, eslint clean, 41 tests pass, production build succeeds.