### PR TITLE
feat: admin area for forvaltere

### DIFF
--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test("anonymous visit to /admin redirects to the login page", async ({
+  page,
+}) => {
+  await page.goto("/admin");
+  await expect(page).toHaveURL(/\/admin\/login/);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Logg inn" }),
+  ).toBeVisible();
+});
+
+test("login form always answers with the generic confirmation", async ({
+  page,
+}) => {
+  await page.goto("/admin/login");
+  await page.getByLabel("E-postadresse").fill("ukjent@tihlde.org");
+  await page.getByRole("button", { name: "Send innloggingslenke" }).click();
+  await expect(
+    page.getByText("Hvis adressen er autorisert, er en innloggingslenke sendt."),
+  ).toBeVisible();
+});

--- a/e2e/site.spec.ts
+++ b/e2e/site.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from "@playwright/test";
 
 const PAGES = [
-  { path: "/", heading: "Fondet" },
+  { path: "/", heading: "TIHLDE sitt fond" },
   { path: "/about", heading: "Om fondet" },
   { path: "/group", heading: "Forvaltningsgruppen" },
   { path: "/group/tidligere", heading: "Tidligere medlemmer" },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,15 @@ const nextConfig = {
       "/api/nordnet": ["./public/reports/**/*"],
       "/api/content": ["./src/data/*.json"],
       "/api/soknader": ["./src/data/*.json"],
+      // Admin routes edit the same JSON files, so the committed fallbacks must
+      // be traced into them as well.
+      "/api/admin/members": ["./src/data/*.json"],
+      "/api/admin/members/[id]": ["./src/data/*.json"],
+      "/api/admin/members/[id]/portrait": ["./src/data/*.json"],
+      "/api/admin/reports": ["./src/data/*.json"],
+      "/api/admin/reports/[index]": ["./src/data/*.json"],
+      "/api/admin/soknader": ["./src/data/*.json"],
+      "/api/admin/soknader/[index]": ["./src/data/*.json"],
     },
   },
   images: {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,32 @@
+import { cookies } from "next/headers";
+import { SESSION_COOKIE } from "@/lib/auth-token";
+import { Button } from "@/components/ui/button";
+
+export const metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Middleware has already verified the token for everything except the login
+  // page; this only decides whether the logout button makes sense to show.
+  const loggedIn = cookies().has(SESSION_COOKIE);
+  return (
+    <div className="w-full max-w-5xl mx-auto px-4 py-8">
+      {loggedIn && (
+        <div className="flex items-center justify-end mb-6">
+          <form action="/api/auth/logout" method="post">
+            <Button type="submit" variant="outline">
+              Logg ut
+            </Button>
+          </form>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,23 @@
+import MembersAdmin from "@/components/admin/MembersAdmin";
+import GroupImagesAdmin from "@/components/admin/GroupImagesAdmin";
+import ReportsAdmin from "@/components/admin/ReportsAdmin";
+import SoknaderAdmin from "@/components/admin/SoknaderAdmin";
+
+export default function AdminPage() {
+  return (
+    <main>
+      <h1 className="text-3xl font-bold text-foreground-primary mb-2">
+        Adminpanel
+      </h1>
+      <p className="text-foreground-secondary mb-10">
+        Endringer lagres med en gang og vises direkte på siden.
+      </p>
+      <div className="space-y-12">
+        <MembersAdmin />
+        <GroupImagesAdmin />
+        <ReportsAdmin />
+        <SoknaderAdmin />
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/admin/group-images/route.ts
+++ b/src/app/api/admin/group-images/route.ts
@@ -1,0 +1,124 @@
+import fs from "fs";
+import path from "path";
+import sharp from "sharp";
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { uploadImageDir } from "@/lib/member-images";
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+// group.jpg / group-2.jpg for the current carousel, group-2024-1.jpg style for
+// the archive on the previous members page. Same convention as
+// resolveGroupImages / resolveArchiveGroupImages.
+const NAME = /^group(-[2-9]|-\d{4}-\d{1,2})?$/;
+const FILE = /^group(-\d+|-\d{4}-\d{1,2})?\.(jpg|jpeg|png|webp)$/;
+
+const REPO_DIR = path.join(process.cwd(), "public", "members");
+
+type GroupImage = { file: string; url: string; source: "volume" | "repo" };
+
+function list(dir: string, source: GroupImage["source"]): GroupImage[] {
+  let files: string[] = [];
+  try {
+    files = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return files
+    .filter((f) => FILE.test(f))
+    .sort()
+    .map((f) => ({
+      file: f,
+      url: source === "repo" ? `/members/${f}` : `/api/members/${f}`,
+      source,
+    }));
+}
+
+export async function GET(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+  const volume = list(uploadImageDir(), "volume");
+  // repo copies shadowed by a volume file with the same name are dropped,
+  // matching how the public pages resolve them
+  const shadowed = new Set(volume.map((i) => i.file));
+  const repo = list(REPO_DIR, "repo").filter((i) => !shadowed.has(i.file));
+  return NextResponse.json({ images: [...volume, ...repo] });
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  const name = String(form?.get("name") ?? "").trim();
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Mangler fil" }, { status: 400 });
+  }
+  if (!NAME.test(name)) {
+    return NextResponse.json(
+      {
+        error:
+          "Ugyldig navn. Bruk group, group-2 ... group-9, eller group-ÅÅÅÅ-N for arkivbilder",
+      },
+      { status: 400 },
+    );
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Bildet er for stort (maks 10 MB)" },
+      { status: 400 },
+    );
+  }
+
+  let processed: Buffer;
+  try {
+    processed = await sharp(Buffer.from(await file.arrayBuffer()))
+      .rotate()
+      .resize(2400, 2400, { fit: "inside", withoutEnlargement: true })
+      .jpeg({ quality: 85 })
+      .toBuffer();
+  } catch {
+    return NextResponse.json(
+      { error: "Filen er ikke et gyldig bilde" },
+      { status: 400 },
+    );
+  }
+
+  const dir = uploadImageDir();
+  fs.mkdirSync(dir, { recursive: true });
+  for (const ext of [".jpeg", ".png", ".webp"]) {
+    fs.rmSync(path.join(dir, name + ext), { force: true });
+  }
+  fs.writeFileSync(path.join(dir, name + ".jpg"), processed);
+  return NextResponse.json({
+    file: `${name}.jpg`,
+    url: `/api/members/${name}.jpg`,
+  });
+}
+
+export async function DELETE(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let file = "";
+  try {
+    const body = await request.json();
+    file = path.basename(String(body?.file ?? ""));
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  if (!FILE.test(file)) {
+    return NextResponse.json({ error: "Ugyldig filnavn" }, { status: 400 });
+  }
+
+  const full = path.join(uploadImageDir(), file);
+  if (fs.existsSync(full)) {
+    fs.rmSync(full);
+    return NextResponse.json({ ok: true });
+  }
+  if (fs.existsSync(path.join(REPO_DIR, file))) {
+    return NextResponse.json(
+      { error: "Bildet ligger i repoet og kan bare fjernes derfra" },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ error: "Fant ikke bildet" }, { status: 404 });
+}

--- a/src/app/api/admin/members/[id]/portrait/route.ts
+++ b/src/app/api/admin/members/[id]/portrait/route.ts
@@ -1,0 +1,92 @@
+import fs from "fs";
+import path from "path";
+import sharp from "sharp";
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson } from "@/lib/data-store";
+import type { MembersFile } from "@/data/members";
+import { IMAGE_EXTENSIONS, uploadImageDir } from "@/lib/member-images";
+
+const MAX_BYTES = 5 * 1024 * 1024;
+
+type Params = { params: { id: string } };
+
+function knownMember(id: string): boolean {
+  const data = readJson<MembersFile>("members");
+  return [...data.allMembers, ...data.previousMembers].some((m) => m.id === id);
+}
+
+// Uploads land as <id>.jpg in the volume dir; sharp decoding doubles as the
+// file type check and strips whatever metadata the original carried.
+export async function POST(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+  const id = params.id;
+  if (!/^[a-z0-9-]+$/.test(id) || !knownMember(id)) {
+    return NextResponse.json({ error: "Fant ikke medlemmet" }, { status: 404 });
+  }
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Mangler fil" }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Bildet er for stort (maks 5 MB)" },
+      { status: 400 },
+    );
+  }
+
+  let processed: Buffer;
+  try {
+    processed = await sharp(Buffer.from(await file.arrayBuffer()))
+      .rotate()
+      .resize(1200, 1200, { fit: "inside", withoutEnlargement: true })
+      .jpeg({ quality: 85 })
+      .toBuffer();
+  } catch {
+    return NextResponse.json(
+      { error: "Filen er ikke et gyldig bilde" },
+      { status: 400 },
+    );
+  }
+
+  const dir = uploadImageDir();
+  fs.mkdirSync(dir, { recursive: true });
+  // drop stale copies in other formats so the new jpg is the one that resolves
+  for (const ext of IMAGE_EXTENSIONS) {
+    if (ext !== ".jpg") fs.rmSync(path.join(dir, id + ext), { force: true });
+  }
+  fs.writeFileSync(path.join(dir, id + ".jpg"), processed);
+  return NextResponse.json({ image: `/api/members/${id}.jpg` });
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+  const id = params.id;
+  if (!/^[a-z0-9-]+$/.test(id)) {
+    return NextResponse.json({ error: "Ugyldig id" }, { status: 400 });
+  }
+
+  const dir = uploadImageDir();
+  let removed = false;
+  for (const ext of IMAGE_EXTENSIONS) {
+    const full = path.join(dir, id + ext);
+    if (fs.existsSync(full)) {
+      fs.rmSync(full);
+      removed = true;
+    }
+  }
+  if (removed) return NextResponse.json({ ok: true });
+
+  const inRepo = IMAGE_EXTENSIONS.some((ext) =>
+    fs.existsSync(path.join(process.cwd(), "public", "members", id + ext)),
+  );
+  if (inRepo) {
+    return NextResponse.json(
+      { error: "Portrettet ligger i repoet og kan bare fjernes derfra" },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ error: "Fant ikke noe portrett" }, { status: 404 });
+}

--- a/src/app/api/admin/members/[id]/route.ts
+++ b/src/app/api/admin/members/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import type { Member, MembersFile } from "@/data/members";
+import { memberFields } from "../helpers";
+
+type Params = { params: { id: string } };
+
+function findMember(data: MembersFile, id: string): Member | undefined {
+  return [...data.allMembers, ...data.previousMembers].find((m) => m.id === id);
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const parsed = memberFields(body);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const data = readJson<MembersFile>("members");
+  const member = findMember(data, params.id);
+  if (!member) {
+    return NextResponse.json({ error: "Fant ikke medlemmet" }, { status: 404 });
+  }
+
+  Object.assign(member, parsed.value);
+  // endYear: null clears it, which moves the person back to current members.
+  if ((body as Record<string, unknown>).endYear === null) delete member.endYear;
+  if (member.linkedin === "") delete member.linkedin;
+  writeJson("members", data);
+  return NextResponse.json(member);
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const data = readJson<MembersFile>("members");
+  if (!findMember(data, params.id)) {
+    return NextResponse.json({ error: "Fant ikke medlemmet" }, { status: 404 });
+  }
+  data.allMembers = data.allMembers.filter((m) => m.id !== params.id);
+  data.previousMembers = data.previousMembers.filter(
+    (m) => m.id !== params.id,
+  );
+  writeJson("members", data);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/members/helpers.test.ts
+++ b/src/app/api/admin/members/helpers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { memberFields, slugify } from "./helpers";
+
+describe("slugify", () => {
+  it("transliterates norwegian letters", () => {
+    expect(slugify("Kaja Sætherhaug Dalåmo")).toBe("kaja-saetherhaug-dalamo");
+    expect(slugify("Bjørn Ødegård")).toBe("bjorn-odegard");
+  });
+
+  it("strips other diacritics and symbols", () => {
+    expect(slugify("Tri Tác Lê")).toBe("tri-tac-le");
+    expect(slugify("  A.  B!  ")).toBe("a-b");
+  });
+});
+
+describe("memberFields", () => {
+  it("keeps only the editable fields", () => {
+    const parsed = memberFields({
+      name: " Kari ",
+      role: "Leder",
+      id: "hacked",
+      image: "https://evil/x.jpg",
+      startYear: 2025,
+    });
+    expect(parsed).toEqual({
+      value: { name: "Kari", role: "Leder", startYear: 2025 },
+    });
+  });
+
+  it("rejects wrong types and out of range years", () => {
+    expect(memberFields({ name: 42 })).toHaveProperty("error");
+    expect(memberFields({ startYear: 1999 })).toHaveProperty("error");
+    expect(memberFields({ endYear: "ikke et tall" })).toHaveProperty("error");
+  });
+
+  it("ignores empty year strings", () => {
+    expect(memberFields({ endYear: "" })).toEqual({ value: {} });
+  });
+});

--- a/src/app/api/admin/members/helpers.ts
+++ b/src/app/api/admin/members/helpers.ts
@@ -1,0 +1,47 @@
+import type { Member } from "@/data/members";
+
+// Member ids follow the portrait file convention: lowercase ascii slug of the
+// name, æøå transliterated (tri-tac-le, kaja-saetherhaug-dalamo).
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/æ/g, "ae")
+    .replace(/ø/g, "o")
+    .replace(/å/g, "a")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const MAX_LEN = 200;
+const STRING_KEYS = ["name", "role", "studie", "linkedin"] as const;
+const YEAR_KEYS = ["startYear", "endYear"] as const;
+
+// Picks the editable fields out of a request body. Unknown keys are dropped,
+// so a payload can never set id or image directly. Returns an error message
+// instead of a value when a present field has the wrong shape.
+export function memberFields(
+  body: unknown,
+): { value: Partial<Member> } | { error: string } {
+  const src = (body ?? {}) as Record<string, unknown>;
+  const out: Partial<Member> = {};
+  for (const key of STRING_KEYS) {
+    const v = src[key];
+    if (v === undefined || v === null) continue;
+    if (typeof v !== "string" || v.length > MAX_LEN) {
+      return { error: `Ugyldig verdi for ${key}` };
+    }
+    out[key] = v.trim();
+  }
+  for (const key of YEAR_KEYS) {
+    const v = src[key];
+    if (v === undefined || v === null || v === "") continue;
+    const n = Number(v);
+    if (!Number.isInteger(n) || n < 2000 || n > 2100) {
+      return { error: `Ugyldig verdi for ${key}` };
+    }
+    out[key] = n;
+  }
+  return { value: out };
+}

--- a/src/app/api/admin/members/route.test.ts
+++ b/src/app/api/admin/members/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+import { createToken, SESSION_COOKIE } from "@/lib/auth-token";
+
+const URL_ = "http://localhost:3000/api/admin/members";
+
+async function sessionCookie(email: string): Promise<string> {
+  return `${SESSION_COOKIE}=${await createToken(email, "session")}`;
+}
+
+beforeEach(() => {
+  process.env.AUTH_SECRET = "test-secret";
+  process.env.ADMIN_EMAILS = "forvalter@tihlde.org";
+});
+
+afterEach(() => {
+  delete process.env.AUTH_SECRET;
+  delete process.env.ADMIN_EMAILS;
+});
+
+describe("admin members auth gate", () => {
+  it("rejects requests without a session cookie", async () => {
+    expect((await GET(new NextRequest(URL_))).status).toBe(401);
+    const res = await POST(new NextRequest(URL_, { method: "POST" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a session for an email no longer on the allowlist", async () => {
+    const cookie = await sessionCookie("fjernet@tihlde.org");
+    const res = await GET(new NextRequest(URL_, { headers: { cookie } }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects writes from a foreign origin even with a valid session", async () => {
+    const cookie = await sessionCookie("forvalter@tihlde.org");
+    const res = await POST(
+      new NextRequest(URL_, {
+        method: "POST",
+        headers: { cookie, origin: "https://angriper.example" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts writes when the Origin matches the Host header", async () => {
+    const cookie = await sessionCookie("forvalter@tihlde.org");
+    const res = await POST(
+      new NextRequest(URL_, {
+        method: "POST",
+        // invalid body: reaching 400 proves the request passed the auth and
+        // origin gates without writing anything
+        body: "ikke json",
+        headers: {
+          cookie,
+          origin: "http://localhost:3000",
+          host: "localhost:3000",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("lets an allowlisted session read", async () => {
+    const cookie = await sessionCookie("forvalter@tihlde.org");
+    const res = await GET(new NextRequest(URL_, { headers: { cookie } }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.allMembers)).toBe(true);
+  });
+});

--- a/src/app/api/admin/members/route.ts
+++ b/src/app/api/admin/members/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import type { Member, MembersFile } from "@/data/members";
+import { memberFields, slugify } from "./helpers";
+
+// Raw members file for the admin UI, both current and previous members.
+export async function GET(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+  return NextResponse.json(readJson<MembersFile>("members"));
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const parsed = memberFields(body);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+  const { name, role, studie, startYear, endYear, linkedin } = parsed.value;
+  if (!name || !role || !studie || !startYear) {
+    return NextResponse.json(
+      { error: "Navn, rolle, studie og startår er påkrevd" },
+      { status: 400 },
+    );
+  }
+
+  const id = slugify(name);
+  if (!id) {
+    return NextResponse.json({ error: "Ugyldig navn" }, { status: 400 });
+  }
+  const data = readJson<MembersFile>("members");
+  const taken = [...data.allMembers, ...data.previousMembers].some(
+    (m) => m.id === id,
+  );
+  if (taken) {
+    return NextResponse.json(
+      { error: `Det finnes allerede et medlem med id ${id}` },
+      { status: 409 },
+    );
+  }
+
+  const member: Member = {
+    id,
+    name,
+    role,
+    studie,
+    startYear,
+    image: "",
+    ...(endYear ? { endYear } : {}),
+    ...(linkedin ? { linkedin } : {}),
+  };
+  if (member.endYear) data.previousMembers.push(member);
+  else data.allMembers.push(member);
+  writeJson("members", data);
+  return NextResponse.json(member, { status: 201 });
+}

--- a/src/app/api/admin/reports/[index]/route.ts
+++ b/src/app/api/admin/reports/[index]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import { reportFields, type ContentFile } from "../helpers";
+
+type Params = { params: { index: string } };
+
+function entryAt(content: ContentFile, raw: string): number {
+  const i = Number(raw);
+  if (!Number.isInteger(i) || i < 0 || i >= content.reports.length) return -1;
+  return i;
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const parsed = reportFields(body);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const content = readJson<ContentFile>("content");
+  const i = entryAt(content, params.index);
+  if (i < 0) {
+    return NextResponse.json({ error: "Fant ikke raden" }, { status: 404 });
+  }
+  Object.assign(content.reports[i], parsed.value);
+  writeJson("content", content);
+  return NextResponse.json(content.reports[i]);
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const content = readJson<ContentFile>("content");
+  const i = entryAt(content, params.index);
+  if (i < 0) {
+    return NextResponse.json({ error: "Fant ikke raden" }, { status: 404 });
+  }
+  content.reports.splice(i, 1);
+  writeJson("content", content);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/reports/helpers.ts
+++ b/src/app/api/admin/reports/helpers.ts
@@ -1,0 +1,29 @@
+export interface ReportEntry {
+  title: string;
+  url: string;
+  type: string;
+}
+
+export interface ContentFile {
+  reports: ReportEntry[];
+}
+
+// Validates a full or partial report entry from a request body.
+export function reportFields(
+  body: unknown,
+): { value: Partial<ReportEntry> } | { error: string } {
+  const src = (body ?? {}) as Record<string, unknown>;
+  const out: Partial<ReportEntry> = {};
+  for (const key of ["title", "url", "type"] as const) {
+    const v = src[key];
+    if (v === undefined || v === null) continue;
+    if (typeof v !== "string" || v.length > 500) {
+      return { error: `Ugyldig verdi for ${key}` };
+    }
+    out[key] = v.trim();
+  }
+  if (out.url && !/^(https:\/\/|\/)/.test(out.url)) {
+    return { error: "Lenken må starte med https:// eller /" };
+  }
+  return { value: out };
+}

--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import { reportFields, type ContentFile } from "./helpers";
+
+// Adds a row to the report list on /reports. The PDF itself is uploaded
+// separately via ./upload; entries can also point at external links.
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const parsed = reportFields(body);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+  const { title, url, type } = parsed.value;
+  if (!title || !url || !type) {
+    return NextResponse.json(
+      { error: "Tittel, lenke og kategori er påkrevd" },
+      { status: 400 },
+    );
+  }
+
+  const content = readJson<ContentFile>("content");
+  content.reports.unshift({ title, url, type });
+  writeJson("content", content);
+  return NextResponse.json({ title, url, type }, { status: 201 });
+}

--- a/src/app/api/admin/reports/upload/route.ts
+++ b/src/app/api/admin/reports/upload/route.ts
@@ -1,0 +1,42 @@
+import fs from "fs";
+import path from "path";
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { getDataDir } from "@/lib/data-store";
+import { slugify } from "../../members/helpers";
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Mangler fil" }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Filen er for stor (maks 10 MB)" },
+      { status: 400 },
+    );
+  }
+
+  const stem = slugify(path.basename(file.name).replace(/\.pdf$/i, ""));
+  if (!stem) {
+    return NextResponse.json({ error: "Ugyldig filnavn" }, { status: 400 });
+  }
+
+  const data = Buffer.from(await file.arrayBuffer());
+  if (!data.subarray(0, 5).toString("latin1").startsWith("%PDF-")) {
+    return NextResponse.json(
+      { error: "Filen er ikke en gyldig PDF" },
+      { status: 400 },
+    );
+  }
+
+  const dir = path.join(getDataDir(), "reports");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${stem}.pdf`), data);
+  return NextResponse.json({ url: `/api/reports/${stem}.pdf` });
+}

--- a/src/app/api/admin/soknader/[index]/route.ts
+++ b/src/app/api/admin/soknader/[index]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import type { Soknad } from "@/data/soknader";
+import { parseSoknad, sortByDatoDesc } from "../helpers";
+
+type Params = { params: { index: string } };
+
+function rowAt(rows: Soknad[], raw: string): number {
+  const i = Number(raw);
+  if (!Number.isInteger(i) || i < 0 || i >= rows.length) return -1;
+  return i;
+}
+
+// Replaces the whole row; the admin form always sends every field.
+export async function PATCH(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const row = parseSoknad(body);
+  if (!row) {
+    return NextResponse.json(
+      { error: "Ugyldig rad. Alle felt må fylles ut, dato som DD.MM.ÅÅÅÅ" },
+      { status: 400 },
+    );
+  }
+
+  const rows = readJson<Soknad[]>("soknader");
+  const i = rowAt(rows, params.index);
+  if (i < 0) {
+    return NextResponse.json({ error: "Fant ikke raden" }, { status: 404 });
+  }
+  rows[i] = row;
+  writeJson("soknader", sortByDatoDesc(rows));
+  return NextResponse.json(row);
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  const rows = readJson<Soknad[]>("soknader");
+  const i = rowAt(rows, params.index);
+  if (i < 0) {
+    return NextResponse.json({ error: "Fant ikke raden" }, { status: 404 });
+  }
+  rows.splice(i, 1);
+  writeJson("soknader", rows);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/soknader/helpers.ts
+++ b/src/app/api/admin/soknader/helpers.ts
@@ -1,0 +1,37 @@
+import type { Soknad } from "@/data/soknader";
+
+const DATO = /^\d{2}\.\d{2}\.\d{4}$/;
+
+function link(v: unknown): { label: string; url: string } | null {
+  const src = (v ?? {}) as Record<string, unknown>;
+  const label = typeof src.label === "string" ? src.label.trim() : "";
+  const url = typeof src.url === "string" ? src.url.trim() : "";
+  if (!label || label.length > 200 || url.length > 500) return null;
+  if (url && !url.startsWith("https://")) return null;
+  return { label, url };
+}
+
+// Validates a complete søknad row. Rows are small enough that partial
+// updates just send the whole row back.
+export function parseSoknad(body: unknown): Soknad | null {
+  const src = (body ?? {}) as Record<string, unknown>;
+  const hvem = typeof src.hvem === "string" ? src.hvem.trim() : "";
+  const hva = typeof src.hva === "string" ? src.hva.trim() : "";
+  const dato = typeof src.dato === "string" ? src.dato.trim() : "";
+  const sokt = link(src.sokt);
+  const resultat = link(src.resultat);
+  const innvilget = (src.resultat as Record<string, unknown>)?.innvilget;
+  if (!hvem || !hva || hvem.length > 200 || hva.length > 200) return null;
+  if (!DATO.test(dato)) return null;
+  if (!sokt || !resultat || typeof innvilget !== "boolean") return null;
+  return { hvem, hva, dato, sokt, resultat: { ...resultat, innvilget } };
+}
+
+function datoValue(dato: string): number {
+  const [d, m, y] = dato.split(".").map(Number);
+  return y * 10000 + m * 100 + d;
+}
+
+export function sortByDatoDesc(rows: Soknad[]): Soknad[] {
+  return [...rows].sort((a, b) => datoValue(b.dato) - datoValue(a.dato));
+}

--- a/src/app/api/admin/soknader/route.ts
+++ b/src/app/api/admin/soknader/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin, unauthorized } from "@/lib/require-admin";
+import { readJson, writeJson } from "@/lib/data-store";
+import type { Soknad } from "@/data/soknader";
+import { parseSoknad, sortByDatoDesc } from "./helpers";
+
+export async function POST(request: NextRequest) {
+  if (!(await requireAdmin(request))) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ugyldig forespørsel" }, { status: 400 });
+  }
+  const row = parseSoknad(body);
+  if (!row) {
+    return NextResponse.json(
+      { error: "Ugyldig rad. Alle felt må fylles ut, dato som DD.MM.ÅÅÅÅ" },
+      { status: 400 },
+    );
+  }
+
+  const rows = readJson<Soknad[]>("soknader");
+  rows.push(row);
+  writeJson("soknader", sortByDatoDesc(rows));
+  return NextResponse.json(row, { status: 201 });
+}

--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { readJson } from "@/lib/data-store";
 
+// Volume-first data: without this the route is static-optimized at build
+// time and admin edits never show.
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   return NextResponse.json(readJson("content"));
 }

--- a/src/app/api/reports/[file]/route.test.ts
+++ b/src/app/api/reports/[file]/route.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { GET } from "./route";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "fondet-reports-"));
+  process.env.DATA_DIR = dir;
+  fs.mkdirSync(path.join(dir, "reports"));
+  fs.writeFileSync(
+    path.join(dir, "reports", "arsrapport-2025.pdf"),
+    "%PDF-1.4 test",
+  );
+});
+
+afterEach(() => {
+  delete process.env.DATA_DIR;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function get(file: string) {
+  return GET(new Request("http://localhost/api/reports/x"), {
+    params: { file },
+  });
+}
+
+describe("GET /api/reports/[file]", () => {
+  it("serves an uploaded pdf", async () => {
+    const res = await get("arsrapport-2025.pdf");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/pdf");
+    expect(await res.text()).toContain("%PDF");
+  });
+
+  it("404s for missing files and non-pdf names", async () => {
+    expect((await get("finnes-ikke.pdf")).status).toBe(404);
+    expect((await get("arsrapport-2025.txt")).status).toBe(404);
+  });
+
+  it("blocks path traversal", async () => {
+    fs.writeFileSync(path.join(dir, "hemmelig.pdf"), "%PDF topp hemmelig");
+    expect((await get("../hemmelig.pdf")).status).toBe(404);
+    expect((await get("..%2Fhemmelig.pdf")).status).toBe(404);
+    expect((await get("%2e%2e/hemmelig.pdf")).status).toBe(404);
+  });
+});

--- a/src/app/api/reports/[file]/route.ts
+++ b/src/app/api/reports/[file]/route.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+import { getDataDir } from "@/lib/data-store";
+
+// Serves PDFs uploaded through the admin area from the volume. Committed
+// reports under public/reports are served statically and never hit this route.
+export async function GET(
+  _req: Request,
+  { params }: { params: { file: string } },
+) {
+  const safe = path.basename(params.file);
+  if (!/^[a-z0-9._-]+\.pdf$/i.test(safe)) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const dir = path.join(getDataDir(), "reports");
+  const full = path.join(dir, safe);
+  if (!full.startsWith(path.resolve(dir)) || !fs.existsSync(full)) {
+    return new Response("Not found", { status: 404 });
+  }
+  const data = await fs.promises.readFile(full);
+  return new Response(new Uint8Array(data), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${safe}"`,
+      "Cache-Control": "public, max-age=3600, must-revalidate",
+    },
+  });
+}

--- a/src/app/api/soknader/route.ts
+++ b/src/app/api/soknader/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { readJson } from "@/lib/data-store";
 import type { Soknad } from "@/data/soknader";
 
+// Volume-first data: without this the route is static-optimized at build
+// time and admin edits never show.
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   return NextResponse.json(readJson<Soknad[]>("soknader"));
 }

--- a/src/components/admin/GroupImagesAdmin.tsx
+++ b/src/components/admin/GroupImagesAdmin.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api, jsonInit, errorMessage } from "./api";
+
+type GroupImage = { file: string; url: string; source: "volume" | "repo" };
+
+export default function GroupImagesAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["admin-group-images"],
+    queryFn: () => api<{ images: GroupImage[] }>("/api/admin/group-images"),
+  });
+  const [name, setName] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function refresh() {
+    await qc.invalidateQueries({ queryKey: ["admin-group-images"] });
+  }
+
+  async function upload(e: React.FormEvent) {
+    e.preventDefault();
+    if (!file) {
+      toast.error("Velg en fil først");
+      return;
+    }
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append("name", name);
+      fd.append("file", file);
+      await api("/api/admin/group-images", { method: "POST", body: fd });
+      await refresh();
+      toast.success("Gruppebilde lastet opp");
+      setName("");
+      setFile(null);
+      (document.getElementById("group-image-file") as HTMLInputElement | null)?.form?.reset();
+    } catch (err) {
+      toast.error(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(img: GroupImage) {
+    if (!confirm(`Slette ${img.file}? Dette kan ikke angres.`)) return;
+    setBusy(true);
+    try {
+      await api("/api/admin/group-images", jsonInit("DELETE", { file: img.file }));
+      await refresh();
+      toast.success("Bilde slettet");
+    } catch (err) {
+      toast.error(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section aria-labelledby="admin-group-images-heading">
+      <h2 id="admin-group-images-heading" className="text-2xl font-bold text-foreground-primary mb-2">
+        Gruppebilder
+      </h2>
+      <p className="text-foreground-secondary mb-4">
+        group og group-2 til group-9 vises i karusellen på gruppesiden.
+        group-ÅÅÅÅ-N, for eksempel group-2024-1, havner i arkivet på siden for
+        tidligere medlemmer.
+      </p>
+
+      <form onSubmit={upload} className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="group-image-name" className="block text-sm font-semibold text-foreground-primary mb-1">
+              Navn
+            </label>
+            <Input
+              id="group-image-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="group, group-2 eller group-2024-1"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="group-image-file" className="block text-sm font-semibold text-foreground-primary mb-1">
+              Bildefil (jpg, png eller webp)
+            </label>
+            <input
+              id="group-image-file"
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className="text-sm text-foreground-secondary py-2"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              required
+            />
+          </div>
+        </div>
+        <Button type="submit" disabled={busy} className="mt-4">
+          Last opp
+        </Button>
+      </form>
+
+      {isLoading && <p className="text-foreground-secondary">Laster bilder ...</p>}
+      {isError && (
+        <p role="alert" className="text-red-500">
+          Kunne ikke laste gruppebildene. Prøv igjen senere.
+        </p>
+      )}
+
+      <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {(data?.images ?? []).map((img) => (
+          <li key={img.file} className="bg-cardBackground border border-cardBorder rounded-lg p-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={img.url} alt={`Gruppebilde ${img.file}`} className="w-full h-32 object-cover rounded" />
+            <p className="text-sm text-foreground-primary mt-2 break-all">{img.file}</p>
+            <p className="text-xs text-foreground-secondary mb-2">
+              {img.source === "volume" ? "Lastet opp" : "Ligger i repoet"}
+            </p>
+            {img.source === "volume" ? (
+              <Button type="button" variant="destructive" className="min-h-[44px] w-full" onClick={() => remove(img)} disabled={busy}>
+                Slett
+              </Button>
+            ) : (
+              <p className="text-xs text-foreground-secondary">Kan bare fjernes fra repoet</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/MembersAdmin.tsx
+++ b/src/components/admin/MembersAdmin.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { Member, MembersFile } from "@/data/members";
+import { api, jsonInit, errorMessage } from "./api";
+
+type FormState = {
+  name: string;
+  role: string;
+  studie: string;
+  startYear: string;
+  endYear: string;
+  linkedin: string;
+};
+
+const EMPTY: FormState = {
+  name: "",
+  role: "",
+  studie: "",
+  startYear: "",
+  endYear: "",
+  linkedin: "",
+};
+
+function toForm(m: Member): FormState {
+  return {
+    name: m.name,
+    role: m.role,
+    studie: m.studie,
+    startYear: String(m.startYear),
+    endYear: m.endYear ? String(m.endYear) : "",
+    linkedin: m.linkedin ?? "",
+  };
+}
+
+function Field({
+  id,
+  label,
+  value,
+  onChange,
+  type = "text",
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-sm font-semibold text-foreground-primary mb-1"
+      >
+        {label}
+      </label>
+      <Input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function MemberForm({
+  idPrefix,
+  form,
+  setForm,
+}: {
+  idPrefix: string;
+  form: FormState;
+  setForm: (f: FormState) => void;
+}) {
+  const set = (key: keyof FormState) => (v: string) =>
+    setForm({ ...form, [key]: v });
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <Field id={`${idPrefix}-name`} label="Navn" value={form.name} onChange={set("name")} />
+      <Field id={`${idPrefix}-role`} label="Rolle" value={form.role} onChange={set("role")} />
+      <Field id={`${idPrefix}-studie`} label="Studie" value={form.studie} onChange={set("studie")} />
+      <Field id={`${idPrefix}-linkedin`} label="LinkedIn-lenke" value={form.linkedin} onChange={set("linkedin")} />
+      <Field id={`${idPrefix}-start`} label="Startår" type="number" value={form.startYear} onChange={set("startYear")} />
+      <Field id={`${idPrefix}-end`} label="Sluttår (tomt for aktive)" type="number" value={form.endYear} onChange={set("endYear")} />
+    </div>
+  );
+}
+
+export default function MembersAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["admin-members"],
+    queryFn: () => api<MembersFile>("/api/admin/members"),
+  });
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [showNew, setShowNew] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const members = data
+    ? [...data.allMembers, ...data.previousMembers].sort((a, b) => {
+        if (!a.endYear !== !b.endYear) return a.endYear ? 1 : -1;
+        if (a.endYear && b.endYear) return b.endYear - a.endYear;
+        return a.startYear - b.startYear;
+      })
+    : [];
+
+  async function run(action: () => Promise<unknown>, done: string) {
+    setBusy(true);
+    try {
+      await action();
+      await qc.invalidateQueries({ queryKey: ["admin-members"] });
+      toast.success(done);
+      return true;
+    } catch (err) {
+      toast.error(errorMessage(err));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function body(patch: boolean) {
+    return {
+      name: form.name,
+      role: form.role,
+      studie: form.studie,
+      linkedin: form.linkedin,
+      startYear: form.startYear ? Number(form.startYear) : undefined,
+      endYear: form.endYear ? Number(form.endYear) : patch ? null : undefined,
+    };
+  }
+
+  async function create() {
+    if (await run(() => api("/api/admin/members", jsonInit("POST", body(false))), "Medlem lagt til")) {
+      setShowNew(false);
+      setForm(EMPTY);
+    }
+  }
+
+  async function save(id: string) {
+    if (await run(() => api(`/api/admin/members/${id}`, jsonInit("PATCH", body(true))), "Medlem oppdatert")) {
+      setEditingId(null);
+    }
+  }
+
+  async function remove(m: Member) {
+    if (!confirm(`Slette ${m.name}? Dette kan ikke angres.`)) return;
+    await run(() => api(`/api/admin/members/${m.id}`, { method: "DELETE" }), "Medlem slettet");
+  }
+
+  async function uploadPortrait(m: Member, file: File) {
+    const fd = new FormData();
+    fd.append("file", file);
+    await run(
+      () => api(`/api/admin/members/${m.id}/portrait`, { method: "POST", body: fd }),
+      `Portrett lastet opp for ${m.name}`,
+    );
+  }
+
+  async function removePortrait(m: Member) {
+    if (!confirm(`Fjerne portrettet til ${m.name}?`)) return;
+    await run(
+      () => api(`/api/admin/members/${m.id}/portrait`, { method: "DELETE" }),
+      "Portrett fjernet",
+    );
+  }
+
+  return (
+    <section aria-labelledby="admin-members-heading">
+      <div className="flex items-center justify-between mb-4">
+        <h2 id="admin-members-heading" className="text-2xl font-bold text-foreground-primary">
+          Medlemmer
+        </h2>
+        <Button
+          type="button"
+          onClick={() => {
+            setShowNew(!showNew);
+            setEditingId(null);
+            setForm(EMPTY);
+          }}
+        >
+          {showNew ? "Avbryt" : "Nytt medlem"}
+        </Button>
+      </div>
+
+      {showNew && (
+        <div className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+          <MemberForm idPrefix="new-member" form={form} setForm={setForm} />
+          <Button type="button" onClick={create} disabled={busy} className="mt-4">
+            Lagre nytt medlem
+          </Button>
+        </div>
+      )}
+
+      {isLoading && <p className="text-foreground-secondary">Laster medlemmer ...</p>}
+      {isError && (
+        <p role="alert" className="text-red-500">
+          Kunne ikke laste medlemmene. Prøv igjen senere.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {members.map((m) => (
+          <li key={m.id} className="bg-cardBackground border border-cardBorder rounded-lg p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="font-semibold text-foreground-primary">
+                  {m.name}
+                  {m.endYear ? (
+                    <span className="font-normal text-foreground-secondary"> (tidligere)</span>
+                  ) : null}
+                </p>
+                <p className="text-sm text-foreground-secondary">
+                  {m.role} - {m.studie} - {m.startYear}
+                  {m.endYear ? ` til ${m.endYear}` : ""}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    if (editingId === m.id) {
+                      setEditingId(null);
+                    } else {
+                      setEditingId(m.id);
+                      setShowNew(false);
+                      setForm(toForm(m));
+                    }
+                  }}
+                >
+                  {editingId === m.id ? "Avbryt" : "Rediger"}
+                </Button>
+                <Button type="button" variant="destructive" className="min-h-[44px] px-4" onClick={() => remove(m)} disabled={busy}>
+                  Slett
+                </Button>
+              </div>
+            </div>
+
+            {editingId === m.id && (
+              <div className="mt-4 border-t border-cardBorder pt-4">
+                <MemberForm idPrefix={`edit-${m.id}`} form={form} setForm={setForm} />
+                <div className="flex flex-wrap items-center gap-4 mt-4">
+                  <Button type="button" onClick={() => save(m.id)} disabled={busy}>
+                    Lagre endringer
+                  </Button>
+                  <div>
+                    <label
+                      htmlFor={`portrait-${m.id}`}
+                      className="block text-sm font-semibold text-foreground-primary mb-1"
+                    >
+                      Last opp portrett (jpg, png eller webp)
+                    </label>
+                    <input
+                      id={`portrait-${m.id}`}
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp"
+                      className="text-sm text-foreground-secondary"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) uploadPortrait(m, file);
+                        e.target.value = "";
+                      }}
+                    />
+                  </div>
+                  <Button type="button" variant="outline" onClick={() => removePortrait(m)} disabled={busy}>
+                    Fjern portrett
+                  </Button>
+                </div>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/ReportsAdmin.tsx
+++ b/src/components/admin/ReportsAdmin.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api, jsonInit, errorMessage } from "./api";
+
+type ReportEntry = { title: string; url: string; type: string };
+type FormState = ReportEntry;
+
+const EMPTY: FormState = { title: "", url: "", type: "" };
+
+function EntryForm({
+  idPrefix,
+  form,
+  setForm,
+  types,
+}: {
+  idPrefix: string;
+  form: FormState;
+  setForm: (f: FormState) => void;
+  types: string[];
+}) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div>
+        <label htmlFor={`${idPrefix}-title`} className="block text-sm font-semibold text-foreground-primary mb-1">
+          Tittel
+        </label>
+        <Input
+          id={`${idPrefix}-title`}
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+        />
+      </div>
+      <div>
+        <label htmlFor={`${idPrefix}-type`} className="block text-sm font-semibold text-foreground-primary mb-1">
+          Kategori
+        </label>
+        <Input
+          id={`${idPrefix}-type`}
+          value={form.type}
+          list="report-types"
+          onChange={(e) => setForm({ ...form, type: e.target.value })}
+        />
+        <datalist id="report-types">
+          {types.map((t) => (
+            <option key={t} value={t} />
+          ))}
+        </datalist>
+      </div>
+      <div>
+        <label htmlFor={`${idPrefix}-url`} className="block text-sm font-semibold text-foreground-primary mb-1">
+          Lenke
+        </label>
+        <Input
+          id={`${idPrefix}-url`}
+          value={form.url}
+          placeholder="/api/reports/... eller https://..."
+          onChange={(e) => setForm({ ...form, url: e.target.value })}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function ReportsAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["admin-content"],
+    queryFn: () => api<{ reports: ReportEntry[] }>("/api/content"),
+  });
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [editing, setEditing] = useState<number | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const reports = data?.reports ?? [];
+  const types = Array.from(new Set(reports.map((r) => r.type)));
+
+  async function run(action: () => Promise<unknown>, done: string) {
+    setBusy(true);
+    try {
+      await action();
+      await qc.invalidateQueries({ queryKey: ["admin-content"] });
+      toast.success(done);
+      return true;
+    } catch (err) {
+      toast.error(errorMessage(err));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function uploadPdf(file: File) {
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const { url } = await api<{ url: string }>("/api/admin/reports/upload", {
+        method: "POST",
+        body: fd,
+      });
+      setForm((f) => ({ ...f, url }));
+      setShowNew(true);
+      setEditing(null);
+      toast.success("PDF lastet opp. Lenken er fylt inn i skjemaet.");
+    } catch (err) {
+      toast.error(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function create() {
+    if (await run(() => api("/api/admin/reports", jsonInit("POST", form)), "Rad lagt til")) {
+      setShowNew(false);
+      setForm(EMPTY);
+    }
+  }
+
+  async function save(index: number) {
+    if (await run(() => api(`/api/admin/reports/${index}`, jsonInit("PATCH", form)), "Rad oppdatert")) {
+      setEditing(null);
+    }
+  }
+
+  async function remove(index: number, entry: ReportEntry) {
+    if (!confirm(`Slette raden "${entry.title}"? Dette kan ikke angres.`)) return;
+    await run(() => api(`/api/admin/reports/${index}`, { method: "DELETE" }), "Rad slettet");
+  }
+
+  return (
+    <section aria-labelledby="admin-reports-heading">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 id="admin-reports-heading" className="text-2xl font-bold text-foreground-primary">
+          Rapporter og dokumenter
+        </h2>
+        <Button
+          type="button"
+          onClick={() => {
+            setShowNew(!showNew);
+            setEditing(null);
+            setForm(EMPTY);
+          }}
+        >
+          {showNew ? "Avbryt" : "Ny rad"}
+        </Button>
+      </div>
+
+      <div className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+        <label htmlFor="report-pdf" className="block text-sm font-semibold text-foreground-primary mb-1">
+          Last opp PDF (maks 10 MB)
+        </label>
+        <input
+          id="report-pdf"
+          type="file"
+          accept="application/pdf"
+          className="text-sm text-foreground-secondary"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) uploadPdf(file);
+            e.target.value = "";
+          }}
+        />
+        <p className="text-xs text-foreground-secondary mt-1">
+          Opplasting fyller inn lenken i radskjemaet. Raden må lagres etterpå
+          for å vises på siden.
+        </p>
+      </div>
+
+      {showNew && (
+        <div className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+          <EntryForm idPrefix="new-report" form={form} setForm={setForm} types={types} />
+          <Button type="button" onClick={create} disabled={busy} className="mt-4">
+            Lagre ny rad
+          </Button>
+        </div>
+      )}
+
+      {isLoading && <p className="text-foreground-secondary">Laster rader ...</p>}
+      {isError && (
+        <p role="alert" className="text-red-500">
+          Kunne ikke laste radene. Prøv igjen senere.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {reports.map((r, i) => (
+          <li key={`${r.title}-${i}`} className="bg-cardBackground border border-cardBorder rounded-lg p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="font-semibold text-foreground-primary">{r.title}</p>
+                <p className="text-sm text-foreground-secondary break-all">
+                  {r.type} - {r.url}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    if (editing === i) {
+                      setEditing(null);
+                    } else {
+                      setEditing(i);
+                      setShowNew(false);
+                      setForm({ title: r.title, url: r.url, type: r.type });
+                    }
+                  }}
+                >
+                  {editing === i ? "Avbryt" : "Rediger"}
+                </Button>
+                <Button type="button" variant="destructive" className="min-h-[44px] px-4" onClick={() => remove(i, r)} disabled={busy}>
+                  Slett
+                </Button>
+              </div>
+            </div>
+            {editing === i && (
+              <div className="mt-4 border-t border-cardBorder pt-4">
+                <EntryForm idPrefix={`edit-report-${i}`} form={form} setForm={setForm} types={types} />
+                <Button type="button" onClick={() => save(i)} disabled={busy} className="mt-4">
+                  Lagre endringer
+                </Button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/SoknaderAdmin.tsx
+++ b/src/components/admin/SoknaderAdmin.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { Soknad } from "@/data/soknader";
+import { api, jsonInit, errorMessage } from "./api";
+
+type FormState = {
+  hvem: string;
+  hva: string;
+  dato: string;
+  soktLabel: string;
+  soktUrl: string;
+  resultatLabel: string;
+  resultatUrl: string;
+  innvilget: boolean;
+};
+
+const EMPTY: FormState = {
+  hvem: "",
+  hva: "",
+  dato: "",
+  soktLabel: "",
+  soktUrl: "",
+  resultatLabel: "",
+  resultatUrl: "",
+  innvilget: true,
+};
+
+function toForm(s: Soknad): FormState {
+  return {
+    hvem: s.hvem,
+    hva: s.hva,
+    dato: s.dato,
+    soktLabel: s.sokt.label,
+    soktUrl: s.sokt.url,
+    resultatLabel: s.resultat.label,
+    resultatUrl: s.resultat.url,
+    innvilget: s.resultat.innvilget,
+  };
+}
+
+function toBody(f: FormState): Soknad {
+  return {
+    hvem: f.hvem,
+    hva: f.hva,
+    dato: f.dato,
+    sokt: { label: f.soktLabel, url: f.soktUrl },
+    resultat: { label: f.resultatLabel, url: f.resultatUrl, innvilget: f.innvilget },
+  };
+}
+
+function SoknadForm({
+  idPrefix,
+  form,
+  setForm,
+}: {
+  idPrefix: string;
+  form: FormState;
+  setForm: (f: FormState) => void;
+}) {
+  const text = (key: keyof FormState, label: string, placeholder = "") => (
+    <div>
+      <label htmlFor={`${idPrefix}-${key}`} className="block text-sm font-semibold text-foreground-primary mb-1">
+        {label}
+      </label>
+      <Input
+        id={`${idPrefix}-${key}`}
+        value={String(form[key])}
+        placeholder={placeholder}
+        onChange={(e) => setForm({ ...form, [key]: e.target.value })}
+      />
+    </div>
+  );
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {text("hvem", "Hvem")}
+      {text("hva", "Hva")}
+      {text("dato", "Dato", "DD.MM.ÅÅÅÅ")}
+      {text("soktLabel", "Søkt beløp")}
+      {text("soktUrl", "Lenke til søknad", "https://...")}
+      {text("resultatLabel", "Resultat")}
+      {text("resultatUrl", "Lenke til vedtak", "https://...")}
+      <div className="flex items-end pb-2">
+        <label className="flex items-center gap-2 text-sm font-semibold text-foreground-primary min-h-[44px]">
+          <input
+            type="checkbox"
+            checked={form.innvilget}
+            onChange={(e) => setForm({ ...form, innvilget: e.target.checked })}
+            className="h-5 w-5"
+          />
+          Innvilget
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export default function SoknaderAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["soknader"],
+    queryFn: () => api<Soknad[]>("/api/soknader"),
+  });
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [editing, setEditing] = useState<number | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const rows = data ?? [];
+
+  async function run(action: () => Promise<unknown>, done: string) {
+    setBusy(true);
+    try {
+      await action();
+      await qc.invalidateQueries({ queryKey: ["soknader"] });
+      toast.success(done);
+      return true;
+    } catch (err) {
+      toast.error(errorMessage(err));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function create() {
+    if (await run(() => api("/api/admin/soknader", jsonInit("POST", toBody(form))), "Søknad lagt til")) {
+      setShowNew(false);
+      setForm(EMPTY);
+    }
+  }
+
+  async function save(index: number) {
+    if (await run(() => api(`/api/admin/soknader/${index}`, jsonInit("PATCH", toBody(form))), "Søknad oppdatert")) {
+      setEditing(null);
+    }
+  }
+
+  async function remove(index: number, row: Soknad) {
+    if (!confirm(`Slette søknaden fra ${row.hvem} (${row.dato})? Dette kan ikke angres.`)) return;
+    await run(() => api(`/api/admin/soknader/${index}`, { method: "DELETE" }), "Søknad slettet");
+  }
+
+  return (
+    <section aria-labelledby="admin-soknader-heading">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 id="admin-soknader-heading" className="text-2xl font-bold text-foreground-primary">
+          Søknader og vedtak
+        </h2>
+        <Button
+          type="button"
+          onClick={() => {
+            setShowNew(!showNew);
+            setEditing(null);
+            setForm(EMPTY);
+          }}
+        >
+          {showNew ? "Avbryt" : "Ny søknad"}
+        </Button>
+      </div>
+
+      {showNew && (
+        <div className="bg-cardBackground border border-cardBorder rounded-lg p-4 mb-6">
+          <SoknadForm idPrefix="new-soknad" form={form} setForm={setForm} />
+          <Button type="button" onClick={create} disabled={busy} className="mt-4">
+            Lagre ny søknad
+          </Button>
+        </div>
+      )}
+
+      {isLoading && <p className="text-foreground-secondary">Laster søknader ...</p>}
+      {isError && (
+        <p role="alert" className="text-red-500">
+          Kunne ikke laste søknadene. Prøv igjen senere.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {rows.map((s, i) => (
+          <li key={`${s.dato}-${s.hvem}-${i}`} className="bg-cardBackground border border-cardBorder rounded-lg p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="font-semibold text-foreground-primary">
+                  {s.hvem} - {s.hva}
+                </p>
+                <p className="text-sm text-foreground-secondary">
+                  {s.dato} - søkt {s.sokt.label} -{" "}
+                  {s.resultat.innvilget ? "innvilget" : "avslått"} {s.resultat.label}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    if (editing === i) {
+                      setEditing(null);
+                    } else {
+                      setEditing(i);
+                      setShowNew(false);
+                      setForm(toForm(s));
+                    }
+                  }}
+                >
+                  {editing === i ? "Avbryt" : "Rediger"}
+                </Button>
+                <Button type="button" variant="destructive" className="min-h-[44px] px-4" onClick={() => remove(i, s)} disabled={busy}>
+                  Slett
+                </Button>
+              </div>
+            </div>
+            {editing === i && (
+              <div className="mt-4 border-t border-cardBorder pt-4">
+                <SoknadForm idPrefix={`edit-soknad-${i}`} form={form} setForm={setForm} />
+                <Button type="button" onClick={() => save(i)} disabled={busy} className="mt-4">
+                  Lagre endringer
+                </Button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/api.ts
+++ b/src/components/admin/api.ts
@@ -1,0 +1,27 @@
+// Small fetch wrapper for the admin sections: throws the server's Norwegian
+// error message so callers can toast it directly.
+export async function api<T = unknown>(
+  url: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(url, init);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(
+      (data as { error?: string }).error || "Noe gikk galt. Prøv igjen.",
+    );
+  }
+  return data as T;
+}
+
+export function jsonInit(method: string, body: unknown): RequestInit {
+  return {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Noe gikk galt. Prøv igjen.";
+}

--- a/src/lib/member-images.ts
+++ b/src/lib/member-images.ts
@@ -9,16 +9,27 @@
 import fs from "fs";
 import path from "path";
 import type { Member } from "@/data/members";
+import { getDataDir } from "@/lib/data-store";
 
-const EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"];
+export const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"];
+const EXTENSIONS = IMAGE_EXTENSIONS;
 
 const REPO_DIR = path.join(process.cwd(), "public", "members");
 
+// Where admin uploads land: the configured volume, or the data dir when
+// MEMBERS_IMAGE_DIR is unset (local dev).
+export function uploadImageDir(): string {
+  return process.env.MEMBERS_IMAGE_DIR || path.join(getDataDir(), "members");
+}
+
 // Directories searched in order; the volume (if configured) overrides the
-// repo copy, and the repo copy is the fallback.
+// repo copy, and the repo copy is the fallback. The upload dir sits in the
+// middle so local admin uploads resolve without MEMBERS_IMAGE_DIR set.
 export function membersImageDirs(): string[] {
   const dirs: string[] = [];
   if (process.env.MEMBERS_IMAGE_DIR) dirs.push(process.env.MEMBERS_IMAGE_DIR);
+  const uploads = uploadImageDir();
+  if (!dirs.includes(uploads)) dirs.push(uploads);
   dirs.push(REPO_DIR);
   return dirs;
 }

--- a/src/lib/require-admin.ts
+++ b/src/lib/require-admin.ts
@@ -1,6 +1,10 @@
-import type { NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { SESSION_COOKIE, verifyToken } from "@/lib/auth-token";
 import { isAllowedEmail } from "@/lib/allowlist";
+
+export function unauthorized(): NextResponse {
+  return NextResponse.json({ error: "Ikke autorisert" }, { status: 401 });
+}
 
 // Gate for the admin API routes. Middleware already guards the /admin pages,
 // but routes re-check here because the allowlist lives on disk and middleware
@@ -13,8 +17,12 @@ export async function requireAdmin(
   if (request.method !== "GET") {
     const origin = request.headers.get("origin");
     if (origin) {
+      // Compare against the Host header, not nextUrl: in the standalone
+      // server nextUrl carries the bind address (0.0.0.0:port), which would
+      // reject every legitimate same-origin request.
+      const host = request.headers.get("host") ?? request.nextUrl.host;
       try {
-        if (new URL(origin).host !== request.nextUrl.host) return null;
+        if (new URL(origin).host !== host) return null;
       } catch {
         return null;
       }


### PR DESCRIPTION
Rebased replacement for #99 (dev moved ahead; the old branch carried duplicate commits and conflicted).

## What

Part 3 of the admin login work (#88, #90): the actual admin area at /admin, gated by the magic-link session.

- Admin API under /api/admin/*, every handler behind requireAdmin (session cookie + allowlist re-read + origin check on writes):
  - members: add, edit, delete; portrait upload (sharp recompress to jpg on the volume) and removal
  - group images: upload/delete with the existing group / group-N / group-YYYY-N naming
  - reports: PDF upload to the volume (served via new public /api/reports/[file] with traversal guard) and CRUD for the rows on /reports
  - soknader: row CRUD, kept sorted newest first
- Admin UI in Norwegian at /admin: four sections, react-query + sonner toasts, confirm before delete, 44px targets

## Fixes found along the way

- /api/content and /api/soknader were static-optimized at build time, so volume edits would never have shown; both are now force-dynamic
- The CSRF origin check compared against nextUrl.host, which in the standalone server is the bind address (0.0.0.0:port); every legitimate same-origin write got 401. Now compares against the Host header
- e2e site spec still expected the old homepage heading from before #85

## Testing

- 78 vitest tests green (13 new: auth gate incl. forged-origin and allowlist-removal, reports traversal guard, slugify/field whitelist)
- Playwright e2e green (36 tests, new admin spec: anonymous redirect + generic login response)
- Manual smoke against the standalone build: member CRUD incl. æøå slugging, portrait upload/serve/delete, PDF upload/serve, report rows, soknad sorting and validation, forged origin rejected, duplicate id 409