### PR TITLE
docs: changelog for admin area, footer copy, drop stray key-export CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ---
 
 ## Neste versjon
+- ✨ **Adminpanel**. Forvaltere kan nå logge inn med engangslenke på e-post (kun @tihlde.org-adresser på adminlisten) og redigere medlemmer, portretter, gruppebilder, rapporter og søknadsoversikten direkte på siden, uten å gå via GitHub.
+- ✨ **Filopplasting**. Portretter og gruppebilder komprimeres automatisk ved opplasting, og rapport-PDF-er lastes opp og serveres fra serverens datalager.
+- ⚡ **Innhold uten deploy**. Endringer gjort i adminpanelet lagres på serverens datavolum og vises umiddelbart, uten ny bygging eller utrulling av siden.
 
 ## Versjon 2026.07.18
 - ⚡ **Søknadsskjema**. Skjemaet varsler nå når ønsket sum overstiger 100 000 kr, siden slike beløp må vedtas av generalforsamlingen. Søknaden kan fortsatt sendes inn.

--- a/api-keys-1784316165021.csv
+++ b/api-keys-1784316165021.csv
@@ -1,2 +1,0 @@
-id,created_at,name,token,permission,domain,creator
-ed7fc32c-aa38-4656-ad68-55b08918d371,2026-01-28 20:11:10.329363+00,Onboarding,re_LLYAfYHc...,sending_access,,tritac.le@gmail.com

--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -75,7 +75,7 @@ const Footer = () => {
             className="inline-flex items-center gap-2 text-sm text-foreground-secondary hover:text-accent transition-colors"
           >
             <FaGithub size={18} />
-            Vil du bidra? Se koden på GitHub
+            Vil du bidra? Send inn PR da vel!
           </a>
         </div>
 


### PR DESCRIPTION
Three small cleanups after the admin area merge.

## Endringer

- CHANGELOG.md: entries under Neste versjon for the admin panel (magic-link login, file uploads, content changes without redeploy). Follows the existing TIHLDE format.
- Footer: contribute link copy changed to "Vil du bidra? Send inn PR da vel!" (restores an edit that was swept into a stash during the admin work).
- Removes api-keys-1784316165021.csv from the repo root (landed via #87). The token column in Resend dashboard exports is truncated, so no usable secret was in the file, but key metadata should not be tracked.

## Test

Docs and copy only; CI verify job covers lint/tsc/build.