### PR TITLE
test: match e2e homepage heading to current h1

### DIFF
--- a/e2e/site.spec.ts
+++ b/e2e/site.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from "@playwright/test";
 
 const PAGES = [
-  { path: "/", heading: "Fondet" },
+  { path: "/", heading: "TIHLDE sitt fond" },
   { path: "/about", heading: "Om fondet" },
   { path: "/group", heading: "Forvaltningsgruppen" },
   { path: "/group/tidligere", heading: "Tidligere medlemmer" },


### PR DESCRIPTION
The homepage h1 changed from "Fondet" to "TIHLDE sitt fond" in #85, but e2e/site.spec.ts still expected the old heading, so the `/` test (desktop + mobile) has failed since. e2e is not part of CI, which is why nothing flagged it.

Full Playwright suite now passes locally on Next 15: 32 passed, 2 skipped.