### PR TITLE
ci: run Playwright e2e in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,16 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm test
       - run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      # playwright.config.ts builds and starts the standalone server itself
+      - run: npx playwright test

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dette dokumentet er skrevet for utviklere som skal videreutvikle eller drifte
 siden. Det forklarer ikke bare hva som er bygget, men hvorfor det er bygget
 slik, og hvilke avveininger som ligger bak.
 
-Stack: Next.js 14 (App Router), TypeScript, Tailwind CSS v4, React Query,
+Stack: Next.js 15 (App Router), TypeScript, Tailwind CSS v4, React Query,
 lightweight-charts (TradingView) og Recharts.
 
 ## Idéen bak arkitekturen


### PR DESCRIPTION
The e2e suite has existed since #42 but never ran in CI, which is how the homepage heading drift from #85 went unnoticed until #106. This adds an e2e job to ci.yml; playwright.config.ts already handles building and serving the standalone bundle, so the job is just install + run. Both projects (desktop Chrome, Pixel 7) use Chromium, so only that browser is installed.

Also updates the README stack line to Next.js 15 after #105.