### PR TITLE
fix: send soknad mail from verified domain, not resend.dev test sender

### DIFF
--- a/src/app/api/soknad/route.ts
+++ b/src/app/api/soknad/route.ts
@@ -90,7 +90,7 @@ ${tillegg || "Ingen"}
 
   try {
     await resend.emails.send({
-      from: "TIHLDE-Fondet Søknad <onboarding@resend.dev>",
+      from: "TIHLDE-Fondet Søknad <fondet@tihlde.org>",
       to: "fondet@tihlde.org",
       replyTo: epost,
       subject: `Søknad om støtte fra ${sokerNavn}: ${Number(onsketSum).toLocaleString("nb-NO")} kr`,


### PR DESCRIPTION
The resend.dev onboarding sender only delivers to the Resend account owner's own address, so applications addressed to fondet@tihlde.org were silently undeliverable in production. Switch to the fondet@tihlde.org sender, same as the login mail. Works once tihlde.org is verified in Resend (in progress, issue #33).