### PR TITLE
fix: holdings table layout jump on row expand, add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: install dev build start lint typecheck test test-watch e2e check
+
+install:
+	npm install
+
+dev:
+	npm run dev
+
+build:
+	npm run build
+
+start:
+	npm run start
+
+lint:
+	npm run lint
+
+typecheck:
+	npx tsc --noEmit
+
+test:
+	npm run test
+
+test-watch:
+	npm run test:watch
+
+e2e:
+	npm run test:e2e
+
+check: lint typecheck test build

--- a/src/components/HoldingsTable.tsx
+++ b/src/components/HoldingsTable.tsx
@@ -350,7 +350,10 @@ export default function HoldingsTable() {
               {isOpen && (
                 <tr id={`detail-${h.legacyInstrumentId}`} className="border-b border-cardBorder last:border-b-0">
                   <td colSpan={COLUMNS.length} className="px-4 pb-4 pt-0">
-                    <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 rounded-lg bg-secondary/60 p-4">
+                    {/* w-0 + min-w-full keeps the colspan cell out of the
+                        auto table layout so opening a row never resizes
+                        the columns above it. */}
+                    <dl className="w-0 min-w-full grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 rounded-lg bg-secondary/60 p-4">
                       <DetailField label="Avkastning 1 md" value={pct(h.performanceOneMonth)} />
                       <DetailField label="Avkastning 5 år" value={pct(h.performanceFiveYears)} />
                       <DetailField label="Referanseindeks" value={h.benchmark ?? "-"} />


### PR DESCRIPTION
## Endringer

- **Layout jump**: expanding a row in Fondets sammensetning changed every column width (Fond went 407 to 503px in testing) because the colspan detail row participates in the auto table layout. The detail grid now gets `w-0 min-w-full`, which zeroes its contribution to column sizing while still rendering full width. Verified in the browser against the live dev site: column widths are now identical closed/open/closed.
- **Makefile**: thin wrapper over the npm scripts (install, dev, build, start, lint, typecheck, test, test-watch, e2e, check).

## Test

Browser-verified fix via DOM patch on fondet.tritacle.no before coding. CI covers lint/tsc/vitest/build/e2e.