### PR TITLE
fix: theme button needed two presses when cycle hit system state

### DIFF
--- a/src/components/navigation/TopBar.tsx
+++ b/src/components/navigation/TopBar.tsx
@@ -32,14 +32,11 @@ const TopBar: React.FC = () => {
     setMenuOpen(false);
   }, [pathname]);
 
+  // Toggle between the two visible themes; "system" is still reachable via
+  // the command palette. Cycling light -> dark -> system here made the button
+  // appear dead when the system preference matched the state it landed on.
   const toggleTheme = () => {
-    if (theme === "light") {
-      setTheme("dark");
-    } else if (theme === "dark") {
-      setTheme("system");
-    } else {
-      setTheme("light");
-    }
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
   };
 
   // Use resolvedTheme directly - this will always be 'light' or 'dark'


### PR DESCRIPTION
The header toggle cycled light -> dark -> system. When the system preference matched the theme it landed on (e.g. dark -> system while the OS is dark), the click produced no visible change, so users pressed twice. The button now flips resolvedTheme directly; Systemtema is still selectable in the command palette (Cmd/Ctrl+K).