### PR TITLE
fix: derive holdings from newest report plus trade feed

### DIFF
--- a/src/app/api/nordnet/route.ts
+++ b/src/app/api/nordnet/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from "next/server";
 import { getProfile, getTrades, getHoldings } from "@/lib/nordnet";
-import { getReportData, reportFundFor } from "@/lib/fordeling";
+import { getReportData, reportFundFor, namesMatch } from "@/lib/fordeling";
+import { readJson } from "@/lib/data-store";
 
 export const revalidate = 1800;
+
+interface Content {
+  soldOut?: string[];
+}
 
 export async function GET() {
   const [profile, trades, report] = await Promise.all([
@@ -10,7 +15,11 @@ export async function GET() {
     getTrades(),
     getReportData(),
   ]);
-  const holdings = await getHoldings(trades);
+  // Funds the Forvaltningsgruppen has confirmed fully sold since the newest
+  // report; the trade feed alone cannot tell a full exit from a partial sell.
+  const soldOut = readJson<Content>("content").soldOut ?? [];
+  const reportFundNames = report?.funds.map((f) => f.name) ?? [];
+  const holdings = await getHoldings(trades, reportFundNames, soldOut);
   const withReport = holdings.map((h) => {
     const fund = reportFundFor(h.name, report);
     return {
@@ -25,7 +34,9 @@ export async function GET() {
     profile,
     holdings: withReport,
     trades: trades.slice(0, 100),
-    fordeling: report?.funds ?? [],
+    fordeling: (report?.funds ?? []).filter(
+      (f) => !soldOut.some((s) => namesMatch(s, f.name)),
+    ),
     weightAsOf: report?.period ?? null,
   });
 }

--- a/src/data/content.json
+++ b/src/data/content.json
@@ -1,4 +1,5 @@
 {
+  "soldOut": ["Öhman Global Growth A"],
   "reports": [
     {
       "title": "Årsrapport 2025",

--- a/src/lib/fordeling.ts
+++ b/src/lib/fordeling.ts
@@ -151,11 +151,23 @@ export async function getReportData(): Promise<ReportData | null> {
   return value;
 }
 
+// A trailing single letter is a share class (A/B/N/P...). Nordnet and the
+// reports sometimes disagree on it for the same fund, so it is stripped
+// before comparison, along with the NOK currency suffix.
 function normalize(name: string): string {
   return name
     .toLowerCase()
     .replace(/\bnok\b/g, "")
+    .replace(/\s+[a-zæøåö]\s*$/, "")
     .replace(/[^a-zæøå0-9]/g, "");
+}
+
+// Same fund under two spellings of its name (share class, currency suffix,
+// one name embedding the other).
+export function namesMatch(left: string, right: string): boolean {
+  const l = normalize(left);
+  const r = normalize(right);
+  return l === r || l.includes(r) || r.includes(l);
 }
 
 // The report entry for a held fund, matched by normalized name. Null when the
@@ -165,12 +177,8 @@ export function reportFundFor(
   data: ReportData | null,
 ): ReportFund | null {
   if (!data) return null;
-  const target = normalize(fundName);
   for (const f of data.funds) {
-    const source = normalize(f.name);
-    if (source === target || source.includes(target) || target.includes(source)) {
-      return f;
-    }
+    if (namesMatch(f.name, fundName)) return f;
   }
   return null;
 }

--- a/src/lib/nordnet-types.ts
+++ b/src/lib/nordnet-types.ts
@@ -37,9 +37,9 @@ export interface Holding {
   prospectusUrl: string | null;
 }
 
-// One fund's line in the newest quarterly report allocation. Unlike Holding,
-// this is the full published portfolio (including funds sold since), so the
-// weights sum to ~100 and can drive an allocation chart.
+// One fund's line in the newest quarterly report allocation, minus funds
+// confirmed fully sold since the report. Weights are the published ones, so
+// they sum to ~100 while nothing has been sold out since.
 export interface FordelingFund {
   name: string;
   weight: number;

--- a/src/lib/nordnet.test.ts
+++ b/src/lib/nordnet.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { deriveHeldTrades } from "./nordnet";
+import { namesMatch } from "./fordeling";
+import type { Trade } from "./nordnet";
+
+let nextId = 1;
+function trade(name: string, tradeType: "BUY" | "SELL", date: string): Trade {
+  return {
+    date,
+    tradeType,
+    name,
+    price: 100,
+    currency: "NOK",
+    logoUrl: null,
+    legacyInstrumentId: nextId++,
+    orderBookId: String(nextId),
+  };
+}
+
+describe("namesMatch", () => {
+  it("matches identical names", () => {
+    expect(namesMatch("DNB Finans A", "DNB Finans A")).toBe(true);
+  });
+
+  it("ignores a differing share class letter", () => {
+    expect(
+      namesMatch(
+        "KLP AksjeGlobal Small Cap Indeks P",
+        "KLP AksjeGlobal Small Cap Indeks N",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores a NOK suffix", () => {
+    expect(namesMatch("Nordnet Global Indeks NOK", "Nordnet Global Indeks")).toBe(
+      true,
+    );
+  });
+
+  it("rejects different funds", () => {
+    expect(namesMatch("Nordnet USA Indeks", "Nordnet Sverige Index")).toBe(false);
+    expect(namesMatch("Öhman Global Growth A", "Lannebo Global Growth A")).toBe(
+      false,
+    );
+  });
+});
+
+describe("deriveHeldTrades", () => {
+  const report = ["KLP AksjeGlobal Small Cap Indeks P", "Fondsfinans Utbytte B"];
+
+  it("keeps funds whose latest trade is a buy", () => {
+    const held = deriveHeldTrades(
+      [trade("Nordnet USA Indeks", "BUY", "2026-03-06")],
+      [],
+      [],
+    );
+    expect(held.map((t) => t.name)).toEqual(["Nordnet USA Indeks"]);
+  });
+
+  it("keeps a report fund after a partial sell", () => {
+    const held = deriveHeldTrades(
+      [trade("KLP AksjeGlobal Small Cap Indeks N", "SELL", "2026-02-27")],
+      report,
+      [],
+    );
+    expect(held.map((t) => t.name)).toEqual([
+      "KLP AksjeGlobal Small Cap Indeks N",
+    ]);
+  });
+
+  it("drops a sold fund that is not in the report", () => {
+    const held = deriveHeldTrades(
+      [trade("Lannebo Global Growth A", "SELL", "2026-02-18")],
+      report,
+      [],
+    );
+    expect(held).toEqual([]);
+  });
+
+  it("drops a report fund listed as sold out", () => {
+    const held = deriveHeldTrades(
+      [trade("Fondsfinans Utbytte B", "SELL", "2026-02-27")],
+      report,
+      ["Fondsfinans Utbytte B"],
+    );
+    expect(held).toEqual([]);
+  });
+
+  it("uses only the latest trade per instrument", () => {
+    const buy = trade("Nordnet Danmark Indeks B", "BUY", "2026-03-06");
+    const sell = { ...buy, tradeType: "SELL" as const, date: "2026-01-10" };
+    // newest first, same instrument: the buy wins
+    const held = deriveHeldTrades([buy, sell], [], []);
+    expect(held.map((t) => t.tradeType)).toEqual(["BUY"]);
+  });
+});

--- a/src/lib/nordnet.ts
+++ b/src/lib/nordnet.ts
@@ -1,6 +1,8 @@
 // Server-side integration against Nordnet's public (unauthenticated) APIs.
-// Holdings weights are not public, so composition is derived from the public
-// trade feed: a fund counts as held when its most recent trade is a buy.
+// Holdings weights are not public, so composition is derived from the newest
+// report's fund list plus the public trade feed (see deriveHeldTrades).
+
+import { namesMatch } from "./fordeling";
 
 const PROFILE_SLUG = "tihlde-forvaltningsgruppen";
 const SHAREVILLE = "https://api.prod.nntech.io/shareville";
@@ -156,15 +158,37 @@ export interface Holding {
   prospectusUrl: string | null;
 }
 
-export async function getHoldings(trades: Trade[]): Promise<Holding[]> {
+// Membership: a fund is held when its latest trade is a buy, or when the
+// newest report lists it (a sell after the report is usually a partial sell,
+// not an exit; the feed has no volumes so the two are indistinguishable).
+// Funds the Forvaltningsgruppen has confirmed fully sold are removed via the
+// soldOut list in content.json. A report fund whose trades have scrolled off
+// the feed window cannot be enriched and is skipped; the next report upload
+// refreshes membership anyway.
+export function deriveHeldTrades(
+  trades: Trade[],
+  reportFundNames: string[],
+  soldOut: string[],
+): Trade[] {
   // trades arrive newest first; the first trade seen per instrument is the latest
   const latest = new Map<number, Trade>();
   for (const t of trades) {
     if (!latest.has(t.legacyInstrumentId)) latest.set(t.legacyInstrumentId, t);
   }
-  const held = Array.from(latest.values()).filter(
-    (t) => t.tradeType === "BUY",
+  return Array.from(latest.values()).filter(
+    (t) =>
+      (t.tradeType === "BUY" ||
+        reportFundNames.some((r) => namesMatch(r, t.name))) &&
+      !soldOut.some((s) => namesMatch(s, t.name)),
   );
+}
+
+export async function getHoldings(
+  trades: Trade[],
+  reportFundNames: string[],
+  soldOut: string[],
+): Promise<Holding[]> {
+  const held = deriveHeldTrades(trades, reportFundNames, soldOut);
 
   const enriched = await Promise.all(
     held.map(async (t) => {


### PR DESCRIPTION
## Problem

The site showed 6 funds while the real portfolio holds 9. Holdings were inferred from the public trade feed alone: a fund counted as held only when its latest trade was a buy. The feed has no volumes, so the partial sells on 27 Feb (KLP AksjeGlobal Small Cap, Fondsfinans Utbytte, DNB Finans) looked like full exits.

## Fix

Membership is now the newest report's fund list adjusted by the trade feed:

- A fund in the newest report stays held through sells (a sell after the report is usually partial).
- A fund bought after the report is added and marked «Ny», as before.
- A fund confirmed fully sold is removed via a new `soldOut` list in content.json (volume-first via data-store, so forvaltere can update it without a deploy). Current entry: Öhman Global Growth A, sold 100 % in February.

Name matching now ignores a trailing share class letter and NOK suffixes, since Nordnet and the reports disagree for the same fund (report says KLP Small Cap «Indeks P», Nordnet says «Indeks N»). The allocation donut also drops sold-out funds.

Weights stay the published report weights; nothing is fabricated. New vitest coverage for `deriveHeldTrades` and `namesMatch`.

## Verification

- `npx vitest run` 87 passed, `npx tsc --noEmit` clean, `npm run build` and `npm run lint` clean.
- Against the live feed: 6 latest-is-buy funds + 3 report funds with partial sells = the 9 funds in the current Nordnet portfolio; Öhman/Lannebo Global Growth excluded.