### PR TITLE
chore: clear placeholder linkedin handles, changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 ## Neste versjon
 
 ## Versjon 2026.07.18
+- ✨ **Filter for tidligere medlemmer**. Listen over tidligere medlemmer kan nå filtreres på rolle og periode.
+- ⚡ **Medlemsrekkefølge**. Fondsforvalter vises først, deretter eldste, og resten etter hvor lenge de har vært med.
+- 🦟 **Temaknapp**. Knappen byttet tidligere innom systemtema, som gjorde at den måtte trykkes to ganger når systemtemaet var likt det aktive. Nå bytter den synlig tema på første trykk; systemtema velges via kommandopaletten.
+- 🦟 **Søknadsmail**. Søknader ble sendt fra Resends testavsender og kom aldri frem; de sendes nå fra fondets egen adresse.
 - ✨ **Adminpanel**. Forvaltere kan nå logge inn med engangslenke på e-post (kun @tihlde.org-adresser på adminlisten) og redigere medlemmer, portretter, gruppebilder, rapporter og søknadsoversikten direkte på siden, uten å gå via GitHub.
 - ✨ **Filopplasting**. Portretter og gruppebilder komprimeres automatisk ved opplasting, og rapport-PDF-er lastes opp og serveres fra serverens datalager.
 - ⚡ **Innhold uten deploy**. Endringer gjort i adminpanelet lagres på serverens datavolum og vises umiddelbart, uten ny bygging eller utrulling av siden.

--- a/src/data/members.json
+++ b/src/data/members.json
@@ -8,7 +8,7 @@
       "image": "",
       "startYear": 2025,
       "studie": "DIGTRANS",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "kaja-saetherhaug-dalamo",
@@ -17,7 +17,7 @@
       "image": "",
       "startYear": 2025,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "kristoffer-langva-qvenild",
@@ -26,7 +26,7 @@
       "image": "",
       "startYear": 2025,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "nina-elise-kashagen",
@@ -35,7 +35,7 @@
       "image": "",
       "startYear": 2025,
       "studie": "DIGSEC",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "oskar-bornick-tveit",
@@ -44,7 +44,7 @@
       "image": "",
       "startYear": 2025,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "sigurd-evensen",
@@ -53,7 +53,7 @@
       "image": "",
       "startYear": 2025,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "edvard-emmanuel-klavenes",
@@ -62,7 +62,7 @@
       "image": "",
       "startYear": 2025,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "thomas-thien-nguyen",
@@ -71,7 +71,7 @@
       "image": "",
       "startYear": 2025,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "martine-lokstad",
@@ -80,7 +80,7 @@
       "image": "",
       "startYear": 2024,
       "studie": "DIGSEC",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "tri-tac-le",
@@ -89,7 +89,7 @@
       "image": "",
       "startYear": 2024,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "kasper-johansen-sando",
@@ -98,7 +98,7 @@
       "image": "",
       "startYear": 2024,
       "studie": "DIGFOR",
-      "linkedin": "tritacle",
+      "linkedin": "",
       "endYear": 2025
     }
   ],
@@ -111,7 +111,7 @@
       "startYear": 2025,
       "endYear": 2026,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "sigurd-evensen-analytiker",
@@ -121,7 +121,7 @@
       "startYear": 2025,
       "endYear": 2025,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "selma-eline-olsen",
@@ -131,7 +131,7 @@
       "startYear": 2024,
       "endYear": 2025,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "imre-romstad",
@@ -141,7 +141,7 @@
       "startYear": 2024,
       "endYear": 2025,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "sigurd-schmidt-hansen",
@@ -151,7 +151,7 @@
       "startYear": 2024,
       "endYear": 2025,
       "studie": "DIGSEC",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "erik-langvik",
@@ -161,7 +161,7 @@
       "startYear": 2024,
       "endYear": 2025,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "mari-hofsrud",
@@ -171,7 +171,7 @@
       "startYear": 2024,
       "endYear": 2025,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "vegard-johnsen",
@@ -181,7 +181,7 @@
       "startYear": 2024,
       "endYear": 2025,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "anton-tveito",
@@ -191,7 +191,7 @@
       "startYear": 2024,
       "endYear": 2025,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "eirik-ryssdalsnes",
@@ -201,7 +201,7 @@
       "startYear": 2024,
       "endYear": 2024,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "andre-karsten",
@@ -211,7 +211,7 @@
       "startYear": 2024,
       "endYear": 2024,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "lars-magne-stangeland",
@@ -221,7 +221,7 @@
       "startYear": 2022,
       "endYear": 2024,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "sandra-hoem",
@@ -231,7 +231,7 @@
       "startYear": 2022,
       "endYear": 2024,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "agnes-bastiansen",
@@ -241,7 +241,7 @@
       "startYear": 2023,
       "endYear": 2024,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "sebastian-sneve",
@@ -251,7 +251,7 @@
       "startYear": 2023,
       "endYear": 2024,
       "studie": "DIGSEC",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "christian-stensoe",
@@ -261,7 +261,7 @@
       "startYear": 2023,
       "endYear": 2024,
       "studie": "DIGSEC",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "oskar-nygren",
@@ -271,7 +271,7 @@
       "startYear": 2022,
       "endYear": 2023,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "herman-westgaard-lund",
@@ -281,7 +281,7 @@
       "startYear": 2022,
       "endYear": 2023,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "hallvard-horgen",
@@ -291,7 +291,7 @@
       "startYear": 2022,
       "endYear": 2023,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "ulrik-aakre",
@@ -301,7 +301,7 @@
       "startYear": 2021,
       "endYear": 2022,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "mikkel-enghaug",
@@ -311,7 +311,7 @@
       "startYear": 2021,
       "endYear": 2022,
       "studie": "DIGFOR",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "helene-wiik",
@@ -321,7 +321,7 @@
       "startYear": 2021,
       "endYear": 2022,
       "studie": "DIGSEC",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "bjornar-osttveit",
@@ -331,7 +331,7 @@
       "startYear": 2021,
       "endYear": 2022,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     },
     {
       "id": "mads-lundegaard",
@@ -341,7 +341,7 @@
       "startYear": 2021,
       "endYear": 2022,
       "studie": "DATA",
-      "linkedin": "tritacle"
+      "linkedin": ""
     }
   ]
 }


### PR DESCRIPTION
Every member entry had linkedin: tritacle, so every member card linked to the same profile. Cleared to empty (no link renders). Changelog entries for the theme toggle fix, member ordering, tidligere filters and soknad sender fix.