### PR TITLE
fix: UX audit round 1: form resilience, contrast, token consistency

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -97,7 +97,7 @@ export default function About() {
         <div className="w-full max-w-6xl mx-auto px-0 sm:px-0 mb-6">
           <Link
             href="/reports"
-            className="block bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg hover:border-gray-500 transition-colors text-center"
+            className="block bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg hover:border-foreground-secondary transition-colors text-center"
           >
             <span className="text-foreground-secondary font-medium">
               Årsrapporter, strategi og vedtekter finner du under Rapporter &rarr;

--- a/src/app/apply/page.tsx
+++ b/src/app/apply/page.tsx
@@ -101,7 +101,7 @@ export default function Apply() {
               <div className="flex justify-center pt-4">
                 <Link
                   href="/apply/skjema"
-                  className="inline-flex items-center px-8 py-3 bg-blue-600 hover:bg-blue-500 text-foreground-primary font-semibold rounded-lg transition-colors text-lg"
+                  className="inline-flex items-center px-8 py-3 bg-blue-600 hover:bg-blue-500 text-white font-semibold rounded-lg transition-colors text-lg"
                 >
                   Søk støtte
                 </Link>

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -45,7 +45,7 @@ export default function Group() {
         <div className="w-full max-w-6xl mx-auto px-4 sm:px-0 mb-6">
           <Link
             href="/group/tidligere"
-            className="block bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg hover:border-gray-500 transition-colors text-center"
+            className="block bg-cardBackground border border-cardBorder rounded-lg p-6 shadow-lg hover:border-foreground-secondary transition-colors text-center"
           >
             <span className="text-foreground-secondary font-medium">
               Se tidligere medlemmer &rarr;

--- a/src/components/SoknadSkjema.tsx
+++ b/src/components/SoknadSkjema.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   TIHLDE_GROUPS,
   validateSoknad,
@@ -17,6 +17,33 @@ import {
 interface BudsjettPost {
   utgift: string;
   sum: string;
+}
+
+// Draft persists across accidental navigation within the tab; cleared on
+// successful submit. sessionStorage, not localStorage, so drafts do not
+// linger on shared machines.
+const DRAFT_KEY = "soknad-draft";
+
+interface Draft {
+  sokerNavn: string;
+  kontaktperson: string;
+  telefon: string;
+  epost: string;
+  onsketSum: string;
+  hvaStotte: string;
+  begrunnelse: string;
+  konsekvenser: string;
+  budsjett: BudsjettPost[];
+  tillegg: string;
+}
+
+function readDraft(): Draft | null {
+  try {
+    const raw = sessionStorage.getItem(DRAFT_KEY);
+    return raw ? (JSON.parse(raw) as Draft) : null;
+  } catch {
+    return null;
+  }
 }
 
 export default function SoknadSkjema() {
@@ -38,6 +65,53 @@ export default function SoknadSkjema() {
     msg: string;
   } | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // Restore any draft after mount; sessionStorage is unavailable during SSR.
+  useEffect(() => {
+    const draft = readDraft();
+    if (!draft) return;
+    setSokerNavn(draft.sokerNavn ?? "");
+    setKontaktperson(draft.kontaktperson ?? "");
+    setTelefon(draft.telefon ?? "");
+    setEpost(draft.epost ?? "");
+    setOnsketSum(draft.onsketSum ?? "");
+    setHvaStotte(draft.hvaStotte ?? "");
+    setBegrunnelse(draft.begrunnelse ?? "");
+    setKonsekvenser(draft.konsekvenser ?? "");
+    if (draft.budsjett?.length) setBudsjett(draft.budsjett);
+    setTillegg(draft.tillegg ?? "");
+  }, []);
+
+  useEffect(() => {
+    const draft: Draft = {
+      sokerNavn,
+      kontaktperson,
+      telefon,
+      epost,
+      onsketSum,
+      hvaStotte,
+      begrunnelse,
+      konsekvenser,
+      budsjett,
+      tillegg,
+    };
+    try {
+      sessionStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+    } catch {
+      // Storage full or blocked; the form still works without drafts.
+    }
+  }, [
+    sokerNavn,
+    kontaktperson,
+    telefon,
+    epost,
+    onsketSum,
+    hvaStotte,
+    begrunnelse,
+    konsekvenser,
+    budsjett,
+    tillegg,
+  ]);
 
   function checkField(name: string, value: string) {
     let err = "";
@@ -133,22 +207,33 @@ export default function SoknadSkjema() {
 
     setSending(true);
 
-    const res = await fetch("/api/soknad", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...soknad, tillegg }),
-    });
-
-    if (res.ok) {
-      setResult({
-        ok: true,
-        msg: "Søknaden er sendt! Du vil høre fra oss.",
+    try {
+      const res = await fetch("/api/soknad", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...soknad, tillegg }),
       });
-    } else {
-      const data = await res.json();
-      setResult({ ok: false, msg: data.error || "Noe gikk galt" });
+
+      if (res.ok) {
+        try {
+          sessionStorage.removeItem(DRAFT_KEY);
+        } catch {}
+        setResult({
+          ok: true,
+          msg: "Søknaden er sendt! Du vil høre fra oss.",
+        });
+      } else {
+        const data = await res.json().catch(() => null);
+        setResult({ ok: false, msg: data?.error || "Noe gikk galt" });
+      }
+    } catch {
+      setResult({
+        ok: false,
+        msg: "Fikk ikke kontakt med serveren. Sjekk nettforbindelsen og prøv igjen. Utfyllingen din er ikke mistet.",
+      });
+    } finally {
+      setSending(false);
     }
-    setSending(false);
   }
 
   const inputClass =
@@ -407,7 +492,7 @@ export default function SoknadSkjema() {
           <button
             type="button"
             onClick={addBudsjettPost}
-            className="text-sm text-blue-400 hover:text-blue-300 font-medium min-h-11 inline-flex items-center px-2 -mx-2 rounded-lg transition-colors"
+            className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium min-h-11 inline-flex items-center px-2 -mx-2 rounded-lg transition-colors"
           >
             + Legg til utgift
           </button>
@@ -438,6 +523,7 @@ export default function SoknadSkjema() {
         {/* Result */}
         {result && (
           <div
+            role={result.ok ? "status" : "alert"}
             className={`p-4 rounded-lg text-sm font-medium ${
               result.ok
                 ? "bg-green-100 border border-green-700 text-green-800 dark:bg-green-900/30 dark:text-green-300"


### PR DESCRIPTION
First batch of fixes from the full WCAG 2.1 AA / UX audit. Every finding was verified against the code before fixing; several audit claims turned out stale or false and were skipped (details below).

## Fixes
- **Soknad form drafts**: fields persist in sessionStorage while typing and clear on successful submit. Navigating away mid-application no longer wipes a long form. sessionStorage rather than localStorage so drafts die with the tab on shared machines.
- **Network failure during submit**: fetch is now wrapped in try/catch/finally. Previously a network error was an unhandled rejection that left the button disabled on "Sender søknad..." forever. Now the button recovers and the message says the input is intact.
- **Screen reader feedback**: the result box gets role="status" (success) or role="alert" (error) so submission outcomome is announced.
- **Contrast**: "+ Legg til utgift" was blue-400 in light mode (2.5:1, fails AA); now blue-600 light / blue-400 dark. Apply CTA used text-foreground-primary on bg-blue-600, nearly invisible in light mode; now white (5.2:1).
- **Theme tokens**: hover:border-gray-500 on about/group cards replaced with hover:border-foreground-secondary.

## Audit claims verified false, skipped
- "Missing KeyMetrics component breaks the build": KeyMetrics is not imported anywhere (removed in #121); build is green.
- "Charts are color-only": ticker has arrows and signs, trades list has Kjøp/Salg text, returns matrix negatives carry a minus sign.
- "Remove button lacks a label": it has aria-label and a 44px target already.

## Testing
- tsc, next build green