### PR TITLE
fix: chart drawing preview cleanup and clearer tool status

### DIFF
--- a/src/components/FundPerformanceChart.tsx
+++ b/src/components/FundPerformanceChart.tsx
@@ -352,6 +352,7 @@ export default function FundPerformanceChart() {
   const [fullscreen, setFullscreen] = useState(false);
   const [activeTool, setActiveTool] = useState<ToolKey | null>(null);
   const [drawings, setDrawings] = useState<Drawing[]>([]);
+  const [pendingPlaced, setPendingPlaced] = useState(false);
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const menusRef = useRef<HTMLDivElement>(null);
@@ -369,9 +370,18 @@ export default function FundPerformanceChart() {
   const idRef = useRef(0);
   const reenterFullscreenRef = useRef(false);
 
+  // Any tool change (activate, switch, cancel) discards the in-progress
+  // drawing: a stale first click must not complete under the new tool, and
+  // the dotted preview series would otherwise stay on the chart forever,
+  // immune to the clear-drawings button.
   useEffect(() => {
     activeToolRef.current = activeTool;
-    if (!activeTool) pendingRef.current = null;
+    pendingRef.current = null;
+    setPendingPlaced(false);
+    if (previewRef.current && chartRef.current) {
+      chartRef.current.removeSeries(previewRef.current);
+      previewRef.current = null;
+    }
   }, [activeTool]);
 
   const fundsParam = useMemo(() => {
@@ -528,10 +538,12 @@ export default function FundPerformanceChart() {
       }
       if (!pendingRef.current) {
         pendingRef.current = p;
+        setPendingPlaced(true);
         return;
       }
       const p1 = pendingRef.current;
       pendingRef.current = null;
+      setPendingPlaced(false);
       removePreview();
       setDrawings((prev) => [
         ...prev,
@@ -1051,6 +1063,7 @@ export default function FundPerformanceChart() {
                     role="menuitem"
                     onClick={() => {
                       setDrawings([]);
+                      setActiveTool(null);
                       setOpenMenu(null);
                     }}
                     className={menuItemClass}
@@ -1100,7 +1113,9 @@ export default function FundPerformanceChart() {
         <p className="text-xs text-foreground-secondary mt-2" role="status">
           {activeTool === "hline"
             ? "Klikk i grafen for å plassere linjen."
-            : "Klikk to punkter i grafen."}{" "}
+            : pendingPlaced
+              ? "Punkt 1 er satt. Klikk punkt 2 for å fullføre tegningen."
+              : "Klikk to punkter i grafen for å tegne."}{" "}
           Esc avbryter.
         </p>
       )}


### PR DESCRIPTION
Fixes #140.

## Problem

- The dotted preview line was only removed when a two-click drawing completed. Esc, switching tools, or hitting the trash button left it on the chart permanently. This is the "trash button does not remove things on screen" bug: the leftover was the preview series, which the clear logic never touched.
- A stale first click survived a tool switch and completed under the new tool with a point from the old one.
- The status line did not tell the user that point 1 was registered.

## Fix

- Any change of active tool (activate, switch, cancel) discards the pending point and removes the preview series.
- "Fjern tegninger" in the Tegn menu also cancels the active tool, matching the standalone trash button.
- Status line now shows "Punkt 1 er satt. Klikk punkt 2 for å fullføre tegningen." after the first click.

## Verify

tsc, lint, 87 unit tests, production build all pass.