### PR TITLE
fix: wrap fund names and headings on mobile instead of truncating

### DIFF
--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -67,7 +67,7 @@ function DocRow({ doc }: { doc: Document }) {
       rel="noopener noreferrer"
       className="group flex items-center gap-3 py-3 px-2 -mx-2 rounded hover:bg-cardBorder/20 transition-colors"
     >
-      <span className="flex-1 min-w-0 truncate text-foreground-primary text-sm font-medium">
+      <span className="flex-1 min-w-0 break-words text-foreground-primary text-sm font-medium">
         {doc.title}
       </span>
       <ExternalLink

--- a/src/components/NordnetProfileCard.tsx
+++ b/src/components/NordnetProfileCard.tsx
@@ -51,8 +51,8 @@ export default function NordnetProfileCard() {
             className="w-16 h-16 rounded-full object-cover border border-cardBorder"
           />
         )}
-        <div className="min-w-0 flex-1">
-          <h2 className="text-xl font-semibold text-foreground-primary truncate">
+        <div className="flex-1 min-w-[10rem]">
+          <h2 className="text-xl font-semibold text-foreground-primary break-words">
             {profile.username}
           </h2>
           <p className="text-sm text-foreground-secondary">

--- a/src/components/ReturnsMatrix.tsx
+++ b/src/components/ReturnsMatrix.tsx
@@ -113,7 +113,7 @@ export default function ReturnsMatrix() {
               <tr key={h.legacyInstrumentId} className="border-b border-cardBorder/50">
                 <th
                   scope="row"
-                  className="py-2 pr-4 text-left font-normal text-foreground-primary max-w-[16rem] truncate"
+                  className="py-2 pr-4 text-left font-normal text-foreground-primary max-w-[16rem] break-words"
                 >
                   {h.name}
                 </th>
@@ -122,7 +122,7 @@ export default function ReturnsMatrix() {
                   return (
                     <td
                       key={p.label}
-                      className={`py-2 px-3 text-right tabular-nums ${
+                      className={`py-2 px-3 text-right tabular-nums whitespace-nowrap ${
                         v === null
                           ? "text-foreground-secondary"
                           : v >= 0

--- a/src/components/TradesList.tsx
+++ b/src/components/TradesList.tsx
@@ -75,7 +75,7 @@ export default function TradesList() {
                   className="w-6 h-6 rounded object-contain"
                 />
               )}
-              <span className="flex-1 min-w-0 truncate text-foreground-primary">
+              <span className="flex-1 min-w-0 break-words text-foreground-primary">
                 {t.name}
               </span>
               <span

--- a/src/components/ui/InfoCard.tsx
+++ b/src/components/ui/InfoCard.tsx
@@ -13,7 +13,7 @@ const InfoCard = ({header, description, imgSrc, type}: InfoCardProps): JSX.Eleme
     return (
         <Card className={`flex flex-col gap-8 md:flex-row-reverse min-h-0 ${type === "rightAlignImage" ? "md:flex-row" : ""}`}>
             <div className="w-full md:w-1/2 flex-col flex gap-4 justify-center">
-                <h2 className="text-2xl sm:text-3xl sm:truncate md:text-4xl font-bold text-pretty">
+                <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-pretty">
                     {header}
                 </h2>
                 <p className="text-foreground-secondary text-base sm:text-lg leading-relaxed">


### PR DESCRIPTION
Fixes #137, part of #136.

At 375 px wide, fund names in the returns matrix, trades list and report rows were cut off with an ellipsis, the Nordnet profile card title rendered as "TIHLDE F...", and InfoCard headings could truncate at the sm breakpoint.

Changes:
- ReturnsMatrix: row headers wrap inside their 16 rem column instead of truncating, and percent cells get whitespace-nowrap so the table scrolls horizontally instead of folding values onto two lines.
- TradesList and reports page rows: names wrap with break-words.
- NordnetProfileCard: title wraps at word boundaries; the name block has a 10 rem minimum width so the Nordnet link wraps below it instead of squeezing the title into mid-word breaks.
- InfoCard: removed sm:truncate from headings.

Verified with Playwright at 375 px on /, /group, /group/tidligere, /reports, /apply and /apply/skjema: no unclipped horizontal overflow on any page, full fund names visible, desktop layout at 1280 px unchanged. Typecheck and lint pass.