### PR TITLE
feat: SMTP transport for outgoing mail as alternative to Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,21 @@
 # Resend API key for the application form and magic-link login emails.
-# Without it the form responds with a clear error and no email is sent.
+# Without it (and without SMTP below) the form responds with a clear error
+# and no email is sent.
 RESEND_API_KEY=
+
+# Optional SMTP server for outgoing mail. When SMTP_HOST is set it takes
+# precedence over Resend, so mail works without a Resend-verified domain.
+# SMTP_PORT defaults to 587 (STARTTLS); 465 uses implicit TLS. SMTP_USER and
+# SMTP_PASS are optional for servers without authentication.
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+
+# Optional. From address for all outgoing mail. Defaults to
+# "TIHLDE Fondet <fondet@tihlde.org>". With SMTP providers like Gmail the
+# address must match the authenticated account.
+MAIL_FROM=
 
 # Public origin of the site, e.g. https://fondet.tihlde.org. Used as the base
 # for magic-link login URLs. Required in production: deriving it from the Host

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lightweight-charts": "^5.2.0",
         "lucide-react": "^0.548.0",
         "next": "^15.5.20",
+        "nodemailer": "^9.0.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-icons": "^5.5.0",
@@ -36,6 +37,7 @@
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "@types/node": "^20.10.5",
+        "@types/nodemailer": "^8.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "eslint": "^8.56.0",
@@ -2400,6 +2402,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -6952,6 +6964,15 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lightweight-charts": "^5.2.0",
     "lucide-react": "^0.548.0",
     "next": "^15.5.20",
+    "nodemailer": "^9.0.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-icons": "^5.5.0",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@types/node": "^20.10.5",
+    "@types/nodemailer": "^8.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "eslint": "^8.56.0",

--- a/src/app/api/soknad/route.ts
+++ b/src/app/api/soknad/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Resend } from "resend";
+import { mailConfigured, sendMail } from "@/lib/send-email";
 import { validateSoknad } from "@/lib/soknad-validation";
 
 export async function POST(request: NextRequest) {
@@ -23,10 +23,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: validationError }, { status: 400 });
   }
 
-  if (!process.env.RESEND_API_KEY) {
+  if (!mailConfigured()) {
     return NextResponse.json({ error: "E-postutsending er ikke konfigurert" }, { status: 503 });
   }
-  const resend = new Resend(process.env.RESEND_API_KEY);
 
   const budsjettLines = (budsjett as { utgift: string; sum: string }[])
     .filter((b) => b.utgift && b.sum)
@@ -89,8 +88,7 @@ ${tillegg || "Ingen"}
 `;
 
   try {
-    await resend.emails.send({
-      from: "TIHLDE-Fondet Søknad <fondet@tihlde.org>",
+    await sendMail({
       to: "fondet@tihlde.org",
       replyTo: epost,
       subject: `Søknad om støtte fra ${sokerNavn}: ${Number(onsketSum).toLocaleString("nb-NO")} kr`,

--- a/src/lib/send-email.ts
+++ b/src/lib/send-email.ts
@@ -1,20 +1,81 @@
 import { Resend } from "resend";
+import nodemailer from "nodemailer";
 
-// Sends the magic link. Without RESEND_API_KEY the link is printed to the
-// server console instead (local dev), except in production where a missing
-// key is a real error.
+interface Mail {
+  to: string;
+  subject: string;
+  text: string;
+  replyTo?: string;
+}
+
+// True when an SMTP server is configured. SMTP takes precedence over Resend
+// so the site can send mail without a Resend-verified domain (issue #133).
+export function smtpConfigured(): boolean {
+  return !!process.env.SMTP_HOST;
+}
+
+export function mailConfigured(): boolean {
+  return smtpConfigured() || !!process.env.RESEND_API_KEY;
+}
+
+function fromAddress(): string {
+  return process.env.MAIL_FROM || "TIHLDE Fondet <fondet@tihlde.org>";
+}
+
+async function sendViaSmtp(mail: Mail): Promise<void> {
+  const port = Number(process.env.SMTP_PORT || 587);
+  const transport = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port,
+    // Port 465 is implicit TLS; 587/25 start plain and upgrade via STARTTLS.
+    secure: port === 465,
+    auth: process.env.SMTP_USER
+      ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+      : undefined,
+  });
+  await transport.sendMail({
+    from: fromAddress(),
+    to: mail.to,
+    replyTo: mail.replyTo,
+    subject: mail.subject,
+    text: mail.text,
+  });
+}
+
+async function sendViaResend(mail: Mail): Promise<void> {
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const { error } = await resend.emails.send({
+    from: fromAddress(),
+    to: mail.to,
+    replyTo: mail.replyTo,
+    subject: mail.subject,
+    text: mail.text,
+  });
+  if (error) throw new Error(error.message);
+}
+
+// Sends through SMTP when configured, otherwise Resend. Callers should check
+// mailConfigured() first if they want to fail with a clear error instead.
+export async function sendMail(mail: Mail): Promise<void> {
+  if (smtpConfigured()) {
+    await sendViaSmtp(mail);
+    return;
+  }
+  await sendViaResend(mail);
+}
+
+// Sends the magic link. With no mail transport configured the link is printed
+// to the server console instead (local dev), except in production where a
+// missing transport is a real error.
 export async function sendLoginEmail(email: string, url: string): Promise<void> {
-  const key = process.env.RESEND_API_KEY;
-  if (!key) {
+  if (!mailConfigured()) {
     if (process.env.NODE_ENV === "production") {
-      throw new Error("RESEND_API_KEY is not set");
+      throw new Error("No mail transport configured: set SMTP_HOST or RESEND_API_KEY");
     }
     console.log(`[auth] innloggingslenke for ${email}: ${url}`);
     return;
   }
-  const resend = new Resend(key);
-  const { error } = await resend.emails.send({
-    from: "TIHLDE Fondet <fondet@tihlde.org>",
+  await sendMail({
     to: email,
     subject: "Innlogging til TIHLDE Fondet",
     text: [
@@ -27,5 +88,4 @@ export async function sendLoginEmail(email: string, url: string): Promise<void> 
       "Hvis du ikke ba om denne e-posten, kan du se bort fra den.",
     ].join("\n"),
   });
-  if (error) throw new Error(error.message);
 }


### PR DESCRIPTION
Closes #133.

Login links and the application form previously required a Resend API key with a verified domain. This adds an SMTP path through nodemailer:

- When SMTP_HOST is set, all outgoing mail (magic-link login and søknad submissions) goes through SMTP. Resend stays as the fallback when only RESEND_API_KEY is set.
- SMTP_PORT defaults to 587 with STARTTLS; 465 uses implicit TLS. SMTP_USER/SMTP_PASS are optional for servers without auth.
- MAIL_FROM overrides the sender address, needed for providers like Gmail that require the authenticated account as sender. Defaults to the existing fondet@tihlde.org sender.
- The søknad route and login mail now share one send path in src/lib/send-email.ts instead of two separate Resend calls.
- .env.example documents the new keys.

Typecheck, lint, all 87 unit tests and the production build pass.