### PR TITLE
chore: promote dev to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,21 @@
 # Resend API key for the application form and magic-link login emails.
-# Without it the form responds with a clear error and no email is sent.
+# Without it (and without SMTP below) the form responds with a clear error
+# and no email is sent.
 RESEND_API_KEY=
+
+# Optional SMTP server for outgoing mail. When SMTP_HOST is set it takes
+# precedence over Resend, so mail works without a Resend-verified domain.
+# SMTP_PORT defaults to 587 (STARTTLS); 465 uses implicit TLS. SMTP_USER and
+# SMTP_PASS are optional for servers without authentication.
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+
+# Optional. From address for all outgoing mail. Defaults to
+# "TIHLDE Fondet <fondet@tihlde.org>". With SMTP providers like Gmail the
+# address must match the authenticated account.
+MAIL_FROM=
 
 # Public origin of the site, e.g. https://fondet.tihlde.org. Used as the base
 # for magic-link login URLs. Required in production: deriving it from the Host

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lightweight-charts": "^5.2.0",
         "lucide-react": "^0.548.0",
         "next": "^15.5.20",
+        "nodemailer": "^9.0.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-icons": "^5.5.0",
@@ -36,6 +37,7 @@
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "@types/node": "^20.10.5",
+        "@types/nodemailer": "^8.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "eslint": "^8.56.0",
@@ -2400,6 +2402,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -6952,6 +6964,15 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lightweight-charts": "^5.2.0",
     "lucide-react": "^0.548.0",
     "next": "^15.5.20",
+    "nodemailer": "^9.0.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-icons": "^5.5.0",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@types/node": "^20.10.5",
+    "@types/nodemailer": "^8.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "eslint": "^8.56.0",

--- a/src/app/api/soknad/route.ts
+++ b/src/app/api/soknad/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Resend } from "resend";
+import { mailConfigured, sendMail } from "@/lib/send-email";
 import { validateSoknad } from "@/lib/soknad-validation";
 
 export async function POST(request: NextRequest) {
@@ -23,10 +23,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: validationError }, { status: 400 });
   }
 
-  if (!process.env.RESEND_API_KEY) {
+  if (!mailConfigured()) {
     return NextResponse.json({ error: "E-postutsending er ikke konfigurert" }, { status: 503 });
   }
-  const resend = new Resend(process.env.RESEND_API_KEY);
 
   const budsjettLines = (budsjett as { utgift: string; sum: string }[])
     .filter((b) => b.utgift && b.sum)
@@ -89,8 +88,7 @@ ${tillegg || "Ingen"}
 `;
 
   try {
-    await resend.emails.send({
-      from: "TIHLDE-Fondet Søknad <fondet@tihlde.org>",
+    await sendMail({
       to: "fondet@tihlde.org",
       replyTo: epost,
       subject: `Søknad om støtte fra ${sokerNavn}: ${Number(onsketSum).toLocaleString("nb-NO")} kr`,

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -67,7 +67,7 @@ function DocRow({ doc }: { doc: Document }) {
       rel="noopener noreferrer"
       className="group flex items-center gap-3 py-3 px-2 -mx-2 rounded hover:bg-cardBorder/20 transition-colors"
     >
-      <span className="flex-1 min-w-0 truncate text-foreground-primary text-sm font-medium">
+      <span className="flex-1 min-w-0 break-words text-foreground-primary text-sm font-medium">
         {doc.title}
       </span>
       <ExternalLink

--- a/src/components/AllocationDonut.tsx
+++ b/src/components/AllocationDonut.tsx
@@ -49,12 +49,54 @@ function normalize(name: string): string {
     .replace(/[^a-zæøå0-9]/g, "");
 }
 
-// Green for a fund up this year, red for down, slate when we have no live
-// return for it. Deep shades: white labels sit at 6.5-7.6:1 on these,
-// well past WCAG AA; the brighter 500/600 shades washed the text out.
+// Graded Finviz-style scale: stronger move this year = brighter shade, so the
+// map shows magnitude, not only direction. Slate when we have no live return.
+// Every fill keeps white labels at 6.2:1 or better; brighter shades than
+// these washed the text out even when they technically passed 4.5:1.
+const SCALE_DOWN = ["#b91c1c", "#991b1b", "#6b2020"]; // <= -8, -8..-3, -3..0
+const SCALE_UP = ["#1d4a2f", "#166534", "#12703a"]; // 0..3, 3..8, >= 8
+const NO_DATA_COLOR = "#475569";
+
 function perfColor(perf: number | null): string {
-  if (perf === null) return "#475569";
-  return perf >= 0 ? "#166534" : "#b91c1c";
+  if (perf === null) return NO_DATA_COLOR;
+  if (perf >= 8) return SCALE_UP[2];
+  if (perf >= 3) return SCALE_UP[1];
+  if (perf >= 0) return SCALE_UP[0];
+  if (perf > -3) return SCALE_DOWN[2];
+  if (perf > -8) return SCALE_DOWN[1];
+  return SCALE_DOWN[0];
+}
+
+// Break a fund name into at most two lines that fit the tile, splitting on
+// spaces. Ellipsis only when a line still cannot fit, so "Fondsfinans
+// Utbytte" wraps instead of becoming "Fondsfinans Utb…".
+function wrapName(name: string, maxChars: number): string[] {
+  if (name.length <= maxChars) return [name];
+  const words = name.split(" ");
+  const lines: string[] = [];
+  let cur = "";
+  let i = 0;
+  while (i < words.length && lines.length < 2) {
+    const next = cur ? `${cur} ${words[i]}` : words[i];
+    if (next.length <= maxChars) {
+      cur = next;
+      i++;
+    } else if (cur) {
+      lines.push(cur);
+      cur = "";
+    } else {
+      cur = words[i];
+      i++;
+      break;
+    }
+  }
+  if (cur && lines.length < 2) lines.push(cur);
+  if (i < words.length || cur.length > maxChars) {
+    const last = lines[lines.length - 1];
+    lines[lines.length - 1] =
+      last.length >= maxChars ? `${last.slice(0, maxChars - 1)}…` : `${last}…`;
+  }
+  return lines;
 }
 
 type TileDatum = FordelingFund & { perf: number | null };
@@ -81,11 +123,9 @@ function DonutTooltip({
     >
       <div className="font-medium">{fund.name}</div>
       <div>{fmt(fund.weight)}</div>
-      {fund.perf !== null && (
-        <div className="text-xs mt-0.5" style={{ opacity: 0.8 }}>
-          {fmtPerf(fund.perf)} i år
-        </div>
-      )}
+      <div className="text-xs mt-0.5" style={{ opacity: 0.8 }}>
+        {fund.perf !== null ? `${fmtPerf(fund.perf)} i år` : "Ingen live kursdata"}
+      </div>
     </div>
   );
 }
@@ -112,13 +152,24 @@ function TreemapTile(props: {
     perf = null,
     cardBg = "#ffffff",
   } = props;
-  // Truncate to what actually fits the tile (~8px per char at 14px bold)
-  // so labels never spill past the tile or the chart edge.
+  // Fit to what the tile can actually hold (~8px per char at 14px bold): the
+  // name wraps onto a second line before it truncates, and every line stays
+  // inside the tile so nothing spills past the chart edge.
   const maxChars = Math.floor((width - 16) / 8);
   const showLabel = !!name && maxChars >= 4 && height > 40;
-  const showSecondLine = height > 56;
-  const label =
-    name && name.length > maxChars ? `${name.slice(0, maxChars - 1)}…` : name;
+  const nameLines = showLabel ? wrapName(name, maxChars) : [];
+  const twoNameLines = nameLines.length > 1 && height > 62;
+  const shownNameLines = twoNameLines ? nameLines : nameLines.slice(0, 1);
+  if (!twoNameLines && nameLines.length > 1 && shownNameLines[0]) {
+    const first = shownNameLines[0];
+    shownNameLines[0] = first.endsWith("…")
+      ? first
+      : first.length >= maxChars
+        ? `${first.slice(0, maxChars - 1)}…`
+        : `${first}…`;
+  }
+  const detailY = twoNameLines ? 57 : 40;
+  const showDetail = height > detailY + 16;
   const detail =
     weight !== undefined
       ? `${fmt(weight)}${perf !== null ? ` · ${fmtPerf(perf)}` : ""}`
@@ -137,22 +188,25 @@ function TreemapTile(props: {
       />
       {showLabel && (
         <>
-          <text
-            x={x + 8}
-            y={y + 21}
-            fill="#ffffff"
-            fontSize={14}
-            fontWeight={700}
-          >
-            {label}
-          </text>
-          {showSecondLine && detail.length <= maxDetailChars && (
+          {shownNameLines.map((line, i) => (
+            <text
+              key={i}
+              x={x + 8}
+              y={y + 21 + i * 17}
+              fill="#ffffff"
+              fontSize={14}
+              fontWeight={700}
+            >
+              {line}
+            </text>
+          ))}
+          {showDetail && detail.length <= maxDetailChars && (
             <text
               x={x + 8}
-              y={y + 40}
+              y={y + detailY}
               fill="#ffffff"
               fontSize={12.5}
-              fontWeight={500}
+              fontWeight={600}
             >
               {detail}
             </text>
@@ -173,7 +227,7 @@ function Legend({ funds }: { funds: TileDatum[] }) {
             style={{ background: COLORS[i % COLORS.length] }}
             aria-hidden
           />
-          <span className="flex-1 min-w-0 truncate text-foreground-primary">
+          <span className="flex-1 min-w-0 break-words text-foreground-primary">
             {f.name}
           </span>
           <span className="text-foreground-secondary tabular-nums">
@@ -233,7 +287,7 @@ export default function AllocationDonut() {
 
   return (
     <div className="w-full">
-      <div className="flex items-start justify-between gap-3 mb-1">
+      <div className="flex flex-wrap items-start justify-between gap-3 mb-1">
         <div>
           <h2 className="text-2xl font-semibold text-foreground-primary">
             Porteføljefordeling
@@ -323,27 +377,25 @@ export default function AllocationDonut() {
               </Treemap>
             </ResponsiveContainer>
           </div>
-          <div className="mt-4 flex flex-wrap items-center gap-4 text-xs text-foreground-secondary">
-            <span className="inline-flex items-center gap-1.5">
-              <span
-                className="w-3 h-3 rounded-sm"
-                style={{ background: "#166534" }}
-                aria-hidden
-              />
-              Opp i år
+          <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-foreground-secondary">
+            <span className="inline-flex items-center gap-2">
+              <span className="inline-flex" aria-hidden>
+                {[...SCALE_DOWN, ...SCALE_UP].map((c) => (
+                  <span
+                    key={c}
+                    className="h-3 w-4 first:rounded-l-sm last:rounded-r-sm"
+                    style={{ background: c }}
+                  />
+                ))}
+              </span>
+              <span>
+                Avkastning i år, fra under -8 % (venstre) til over +8 % (høyre)
+              </span>
             </span>
             <span className="inline-flex items-center gap-1.5">
               <span
                 className="w-3 h-3 rounded-sm"
-                style={{ background: "#b91c1c" }}
-                aria-hidden
-              />
-              Ned i år
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <span
-                className="w-3 h-3 rounded-sm"
-                style={{ background: "#475569" }}
+                style={{ background: NO_DATA_COLOR }}
                 aria-hidden
               />
               Ingen live kurs

--- a/src/components/FundPerformanceChart.tsx
+++ b/src/components/FundPerformanceChart.tsx
@@ -352,6 +352,7 @@ export default function FundPerformanceChart() {
   const [fullscreen, setFullscreen] = useState(false);
   const [activeTool, setActiveTool] = useState<ToolKey | null>(null);
   const [drawings, setDrawings] = useState<Drawing[]>([]);
+  const [pendingPlaced, setPendingPlaced] = useState(false);
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const menusRef = useRef<HTMLDivElement>(null);
@@ -369,9 +370,18 @@ export default function FundPerformanceChart() {
   const idRef = useRef(0);
   const reenterFullscreenRef = useRef(false);
 
+  // Any tool change (activate, switch, cancel) discards the in-progress
+  // drawing: a stale first click must not complete under the new tool, and
+  // the dotted preview series would otherwise stay on the chart forever,
+  // immune to the clear-drawings button.
   useEffect(() => {
     activeToolRef.current = activeTool;
-    if (!activeTool) pendingRef.current = null;
+    pendingRef.current = null;
+    setPendingPlaced(false);
+    if (previewRef.current && chartRef.current) {
+      chartRef.current.removeSeries(previewRef.current);
+      previewRef.current = null;
+    }
   }, [activeTool]);
 
   const fundsParam = useMemo(() => {
@@ -528,10 +538,12 @@ export default function FundPerformanceChart() {
       }
       if (!pendingRef.current) {
         pendingRef.current = p;
+        setPendingPlaced(true);
         return;
       }
       const p1 = pendingRef.current;
       pendingRef.current = null;
+      setPendingPlaced(false);
       removePreview();
       setDrawings((prev) => [
         ...prev,
@@ -1051,6 +1063,7 @@ export default function FundPerformanceChart() {
                     role="menuitem"
                     onClick={() => {
                       setDrawings([]);
+                      setActiveTool(null);
                       setOpenMenu(null);
                     }}
                     className={menuItemClass}
@@ -1100,7 +1113,9 @@ export default function FundPerformanceChart() {
         <p className="text-xs text-foreground-secondary mt-2" role="status">
           {activeTool === "hline"
             ? "Klikk i grafen for å plassere linjen."
-            : "Klikk to punkter i grafen."}{" "}
+            : pendingPlaced
+              ? "Punkt 1 er satt. Klikk punkt 2 for å fullføre tegningen."
+              : "Klikk to punkter i grafen for å tegne."}{" "}
           Esc avbryter.
         </p>
       )}

--- a/src/components/NordnetProfileCard.tsx
+++ b/src/components/NordnetProfileCard.tsx
@@ -51,8 +51,8 @@ export default function NordnetProfileCard() {
             className="w-16 h-16 rounded-full object-cover border border-cardBorder"
           />
         )}
-        <div className="min-w-0 flex-1">
-          <h2 className="text-xl font-semibold text-foreground-primary truncate">
+        <div className="flex-1 min-w-[10rem]">
+          <h2 className="text-xl font-semibold text-foreground-primary break-words">
             {profile.username}
           </h2>
           <p className="text-sm text-foreground-secondary">

--- a/src/components/ReturnsMatrix.tsx
+++ b/src/components/ReturnsMatrix.tsx
@@ -113,7 +113,7 @@ export default function ReturnsMatrix() {
               <tr key={h.legacyInstrumentId} className="border-b border-cardBorder/50">
                 <th
                   scope="row"
-                  className="py-2 pr-4 text-left font-normal text-foreground-primary max-w-[16rem] truncate"
+                  className="py-2 pr-4 text-left font-normal text-foreground-primary max-w-[16rem] break-words"
                 >
                   {h.name}
                 </th>
@@ -122,7 +122,7 @@ export default function ReturnsMatrix() {
                   return (
                     <td
                       key={p.label}
-                      className={`py-2 px-3 text-right tabular-nums ${
+                      className={`py-2 px-3 text-right tabular-nums whitespace-nowrap ${
                         v === null
                           ? "text-foreground-secondary"
                           : v >= 0

--- a/src/components/TradesList.tsx
+++ b/src/components/TradesList.tsx
@@ -75,7 +75,7 @@ export default function TradesList() {
                   className="w-6 h-6 rounded object-contain"
                 />
               )}
-              <span className="flex-1 min-w-0 truncate text-foreground-primary">
+              <span className="flex-1 min-w-0 break-words text-foreground-primary">
                 {t.name}
               </span>
               <span

--- a/src/components/ui/InfoCard.tsx
+++ b/src/components/ui/InfoCard.tsx
@@ -13,7 +13,7 @@ const InfoCard = ({header, description, imgSrc, type}: InfoCardProps): JSX.Eleme
     return (
         <Card className={`flex flex-col gap-8 md:flex-row-reverse min-h-0 ${type === "rightAlignImage" ? "md:flex-row" : ""}`}>
             <div className="w-full md:w-1/2 flex-col flex gap-4 justify-center">
-                <h2 className="text-2xl sm:text-3xl sm:truncate md:text-4xl font-bold text-pretty">
+                <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-pretty">
                     {header}
                 </h2>
                 <p className="text-foreground-secondary text-base sm:text-lg leading-relaxed">

--- a/src/lib/send-email.ts
+++ b/src/lib/send-email.ts
@@ -1,20 +1,81 @@
 import { Resend } from "resend";
+import nodemailer from "nodemailer";
 
-// Sends the magic link. Without RESEND_API_KEY the link is printed to the
-// server console instead (local dev), except in production where a missing
-// key is a real error.
+interface Mail {
+  to: string;
+  subject: string;
+  text: string;
+  replyTo?: string;
+}
+
+// True when an SMTP server is configured. SMTP takes precedence over Resend
+// so the site can send mail without a Resend-verified domain (issue #133).
+export function smtpConfigured(): boolean {
+  return !!process.env.SMTP_HOST;
+}
+
+export function mailConfigured(): boolean {
+  return smtpConfigured() || !!process.env.RESEND_API_KEY;
+}
+
+function fromAddress(): string {
+  return process.env.MAIL_FROM || "TIHLDE Fondet <fondet@tihlde.org>";
+}
+
+async function sendViaSmtp(mail: Mail): Promise<void> {
+  const port = Number(process.env.SMTP_PORT || 587);
+  const transport = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port,
+    // Port 465 is implicit TLS; 587/25 start plain and upgrade via STARTTLS.
+    secure: port === 465,
+    auth: process.env.SMTP_USER
+      ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+      : undefined,
+  });
+  await transport.sendMail({
+    from: fromAddress(),
+    to: mail.to,
+    replyTo: mail.replyTo,
+    subject: mail.subject,
+    text: mail.text,
+  });
+}
+
+async function sendViaResend(mail: Mail): Promise<void> {
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const { error } = await resend.emails.send({
+    from: fromAddress(),
+    to: mail.to,
+    replyTo: mail.replyTo,
+    subject: mail.subject,
+    text: mail.text,
+  });
+  if (error) throw new Error(error.message);
+}
+
+// Sends through SMTP when configured, otherwise Resend. Callers should check
+// mailConfigured() first if they want to fail with a clear error instead.
+export async function sendMail(mail: Mail): Promise<void> {
+  if (smtpConfigured()) {
+    await sendViaSmtp(mail);
+    return;
+  }
+  await sendViaResend(mail);
+}
+
+// Sends the magic link. With no mail transport configured the link is printed
+// to the server console instead (local dev), except in production where a
+// missing transport is a real error.
 export async function sendLoginEmail(email: string, url: string): Promise<void> {
-  const key = process.env.RESEND_API_KEY;
-  if (!key) {
+  if (!mailConfigured()) {
     if (process.env.NODE_ENV === "production") {
-      throw new Error("RESEND_API_KEY is not set");
+      throw new Error("No mail transport configured: set SMTP_HOST or RESEND_API_KEY");
     }
     console.log(`[auth] innloggingslenke for ${email}: ${url}`);
     return;
   }
-  const resend = new Resend(key);
-  const { error } = await resend.emails.send({
-    from: "TIHLDE Fondet <fondet@tihlde.org>",
+  await sendMail({
     to: email,
     subject: "Innlogging til TIHLDE Fondet",
     text: [
@@ -27,5 +88,4 @@ export async function sendLoginEmail(email: string, url: string): Promise<void> 
       "Hvis du ikke ba om denne e-posten, kan du se bort fra den.",
     ].join("\n"),
   });
-  if (error) throw new Error(error.message);
 }


### PR DESCRIPTION
Brings the issue-fix round to production:

- Chart drawing cleanup: trash button and tool switches now remove in-progress preview lines, clearer status text (PR #141). Closes #140.
- Treemap redesign: graded diverging color scale, wrapped tile labels, no-data legend entry (PR #142). Closes #129.
- Mobile fixes: fund names and headings wrap instead of truncating across matrix, trades, reports, profile card and InfoCard (PR #145). Closes #136. Closes #137.
- SMTP transport as alternative to Resend for login links and søknad mail (PR #146). Closes #133.
- Updated member portraits.