### PR TITLE
chore: retire dev branch workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Build and push image
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -23,9 +23,7 @@ jobs:
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+          tags: type=raw,value=latest
       - uses: docker/build-push-action@v7
         with:
           context: .

--- a/README.md
+++ b/README.md
@@ -132,9 +132,8 @@ Alt hentes uten innlogging. Integrasjonen ligger i `src/lib/nordnet.ts`.
 ## Hosting og deploy
 
 Appen bygges som et Docker-image (`output: "standalone"`) og publiseres til
-GitHub Container Registry av GitHub Actions. Push til `dev` gir tag `:dev`, push
-til `main` gir `:latest`. CI (lint, typesjekk, tester, build) kjører på alle
-pusher og pull requests.
+GitHub Container Registry av GitHub Actions. Push til `main` gir tag `:latest`.
+CI (lint, typesjekk, tester, build) kjører på alle pusher og pull requests.
 
 ```mermaid
 flowchart LR

--- a/systemd/fondet.service
+++ b/systemd/fondet.service
@@ -14,7 +14,7 @@ ExecStart=/usr/bin/docker run --rm \
     -e DATA_DIR=/app/data \
     -e MEMBERS_IMAGE_DIR=/app/data/members \
     -v %h/srv/Fondet/data:/app/data \
-    ghcr.io/tihlde/fondet:dev
+    ghcr.io/tihlde/fondet:latest
 ExecStop=/usr/bin/docker stop fondet
 Restart=always
 RestartSec=10


### PR DESCRIPTION
The dev branch is being removed; PRs target main directly from now on.

- docker.yml builds only :latest on main pushes
- systemd/fondet.service pulls :latest instead of :dev (needs a symlink refresh + daemon-reload + restart on the server after merge, which I will do)
- ci.yml push trigger drops dev
- README deploy section updated

After this merges and the server is switched to :latest, the dev branch and the :dev image tag are unused.