### PR TITLE
fix: gate the :latest image tag to the main ref

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: type=raw,value=latest
+          tags: type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
       - uses: docker/build-push-action@v7
         with:
           context: .


### PR DESCRIPTION
PR #154 simplified the docker tags line and lost the `enable=${{ github.ref == 'refs/heads/main' }}` condition. The workflow still has workflow_dispatch, so a manual run from any branch could push :latest, which prod auto-pulls with --pull=always. This restores the gate: dispatch runs from other refs build nothing.