### PR TITLE
fix: background of ticker bar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ import Reveal from "../components/Reveal";
 export default function Home() {
   return (
     <div className="w-full min-h-screen bg-gradient-primary overflow-x-hidden">
-      <main className="flex flex-col items-center justify-center sm:px-8 sm:pb-8 pt-24">
+      <main className="flex flex-col items-center justify-center sm:px-8 sm:pb-8 pt-20">
         {/* Full-width terminal ticker: YTD return per fund, live from Nordnet */}
         <FundTicker />
 

--- a/src/components/FundTicker.tsx
+++ b/src/components/FundTicker.tsx
@@ -45,9 +45,11 @@ export default function FundTicker() {
   const label = "Avkastning hittil i år per fond";
 
   // Full-bleed terminal bar: a fixed dark band, edge to edge, that carries the
-  // funds regardless of the page theme.
+  // funds regardless of the page theme. ticker-band is defined in globals.css
+  // with hardcoded hex values so Tailwind v4 arbitrary-class issues can't cause
+  // it to appear transparent/white in light mode.
   const band =
-    "w-screen ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] border-y border-[#2a2e39] bg-[#0a0e17]";
+    "ticker-band w-screen ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] border-y";
 
   if (reduce) {
     return (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -116,6 +116,12 @@ body {
   }
 }
 
+/* Fund ticker band: always dark regardless of page theme. */
+.ticker-band {
+  background-color: #0a0e17;
+  border-color: #2a2e39;
+}
+
 /* Fund ticker: two stacked copies scroll left, looping at -50%. Pauses on
    hover or keyboard focus so a value can be read. */
 @keyframes ticker {


### PR DESCRIPTION
This pull request updates the fund ticker's appearance to ensure it always displays with a consistent dark background, regardless of the page theme or Tailwind CSS version. The main change is the introduction of a dedicated CSS class for the ticker band, which resolves issues with arbitrary Tailwind classes appearing incorrectly in light mode.

**Fund Ticker Styling Consistency:**
* Added a `.ticker-band` CSS class in `globals.css` to enforce a fixed dark background and border color for the fund ticker bar, ensuring it remains visually consistent across themes and Tailwind versions.
* Updated `FundTicker.tsx` to use the new `ticker-band` class instead of inline Tailwind color classes, preventing display issues in light mode.

**Layout Adjustment:**
* Reduced the top padding of the main content area in `page.tsx` from `pt-24` to `pt-20` for improved vertical spacing.